### PR TITLE
fix: migrate JWT from python-jose to PyJWT (resolves Dependabot #4)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update as sa_update
 from passlib.context import CryptContext
-from jose import JWTError, jwt
+import jwt
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 from app.database import get_db
@@ -36,7 +36,7 @@ async def get_current_user(token: str = Depends(oauth2_scheme), db: AsyncSession
     try:
         payload = jwt.decode(token, get_settings().secret_key, algorithms=[ALGORITHM])
         user_id = UUID(payload["sub"])
-    except (JWTError, KeyError, ValueError):
+    except (jwt.PyJWTError, KeyError, ValueError):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "python-telegram-bot>=21.5",
     "numpy>=1.26.0",
     "beautifulsoup4>=4.12.0",
-    "python-jose[cryptography]>=3.3.0",
+    "pyjwt>=2.9.0",
     "passlib[bcrypt]>=1.7.4",
     "python-multipart>=0.0.9",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -613,18 +613,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
-]
-
-[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1418,15 +1406,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1618,25 +1597,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
@@ -1729,18 +1689,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "sendgrid"
 version = "6.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1792,7 +1740,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
-    { name = "python-jose", extra = ["cryptography"] },
+    { name = "pyjwt" },
     { name = "python-multipart" },
     { name = "python-telegram-bot" },
     { name = "redis" },
@@ -1827,9 +1775,9 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.8.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
+    { name = "pyjwt", specifier = ">=2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "python-telegram-bot", specifier = ">=21.5" },
     { name = "redis", specifier = ">=5.0.0" },


### PR DESCRIPTION
## Summary
Resolves Dependabot alert #4 — `ecdsa` (Minerva timing attack on P-256, high severity, no upstream fix available). `ecdsa` was pulled as a transitive dep via `python-jose[cryptography]`. The cleanest fix is to migrate off `python-jose` entirely.

## What changed
- `backend/pyproject.toml`: replaced `python-jose[cryptography]>=3.3.0` with `pyjwt>=2.9.0`
- `backend/uv.lock`: regenerated — removes `ecdsa`, `pyasn1`, `python-jose`, `rsa`
- `backend/app/routers/auth.py`: 3-line change
  - `from jose import JWTError, jwt` → `import jwt`
  - `except (JWTError, KeyError, ValueError)` → `except (jwt.PyJWTError, KeyError, ValueError)`

## Why PyJWT
- Near-identical API to `jose.jwt` — the `encode`/`decode` call sites are unchanged
- No `ecdsa` dependency
- Actively maintained
- Used by most FastAPI auth tutorials already

## Verification
- `docker compose exec -T api uv sync --all-extras` confirms 4 packages uninstalled: `ecdsa 0.19.2`, `pyasn1 0.6.3`, `python-jose 3.5.0`, `rsa 4.9.1`
- `grep -c 'ecdsa' backend/uv.lock` returns 0
- Manual round-trip test inside the container: `create_access_token` → `jwt.decode` correctly extracts `sub` and `workspace_id`; `jwt.PyJWTError` correctly catches invalid tokens

## Test plan
- [x] `pyjwt` imports cleanly (version 2.12.1 installed)
- [x] Round-trip JWT encode/decode works with existing `SECRET_KEY` and HS256
- [x] `jwt.PyJWTError` subsumes `jose.JWTError`'s role in the exception handler
- [ ] Full `test_auth.py::test_register_and_login` will run green after the `feat/phase-2-foundation-impl` branch's conftest fix is merged (the test is currently blocked on a pre-existing pytest-asyncio fixture bug, unrelated to this PR)

## Dependabot after merge
Alert #4 should auto-resolve within a few minutes of merging.