### PR TITLE
fix: add ForeignKey constraints to Connection.workspace_id and user_id (closes #8)

### DIFF
--- a/backend/app/models/connection.py
+++ b/backend/app/models/connection.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Float, Boolean, Integer, ARRAY, Text, UniqueConstraint
+from sqlalchemy import Column, String, Float, Boolean, Integer, ARRAY, Text, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from app.models._types import TIMESTAMPTZ
 import uuid
@@ -9,8 +9,8 @@ class Connection(Base):
     __table_args__ = (UniqueConstraint("workspace_id", "linkedin_id"),)
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    workspace_id = Column(UUID(as_uuid=True), nullable=False)
-    user_id = Column(UUID(as_uuid=True), nullable=False)
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     linkedin_id = Column(String, nullable=False)
     name = Column(String, nullable=False)
     headline = Column(Text)


### PR DESCRIPTION
## Summary

ORM-only fix: adds `ForeignKey("workspaces.id")` and `ForeignKey("users.id")` to the `Connection` model's `workspace_id` and `user_id` columns. The DB-level FK constraints already exist from migration 001; the ORM was just out of sync.

## Why this matters

Without the `ForeignKey(...)` declaration in the ORM, `Base.metadata.create_all` (used by `backend/tests/conftest.py` to build the test DB) created the `connections` table without FK constraints. Tests could insert orphan rows (rows referencing non-existent workspaces or users) that production would reject. That asymmetry hid bugs.

This matches the pattern that was applied to `Post.connection_id` in commit `15a5e31` during Task 1 fixup of the Foundation PR.

## Changes

`backend/app/models/connection.py` — 3 line delta:
1. Added `ForeignKey` to the `sqlalchemy` import
2. `workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)`
3. `user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)`

No migration, no schema change, no behavior change — the database already enforces these constraints.

## Test plan

- [x] Full suite: **48 pass / 2 fail** (unchanged from main baseline)
- [x] Phase 2 Foundation tests still pass
- [x] The 2 remaining failures are unrelated: issue #6 (Slack router) and issue #11 (test_e2e OpenAI mocking)

Closes #8