### PR TITLE
fix(auth): require explicit exp/sub claims in jwt.decode (closes #7)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -34,9 +34,14 @@ def create_access_token(user_id: UUID, workspace_id: UUID) -> str:
 
 async def get_current_user(token: str = Depends(oauth2_scheme), db: AsyncSession = Depends(get_db)) -> User:
     try:
-        payload = jwt.decode(token, get_settings().secret_key, algorithms=[ALGORITHM])
+        payload = jwt.decode(
+            token,
+            get_settings().secret_key,
+            algorithms=[ALGORITHM],
+            options={"require": ["exp", "sub"]},
+        )
         user_id = UUID(payload["sub"])
-    except (jwt.PyJWTError, KeyError, ValueError):
+    except (jwt.PyJWTError, ValueError):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,6 +1,13 @@
 import pytest
+import jwt
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 from httpx import AsyncClient, ASGITransport
 from app.main import app
+from app.config import get_settings
+
+ALGORITHM = "HS256"
+
 
 @pytest.mark.asyncio
 async def test_register_and_login(client):
@@ -19,3 +26,50 @@ async def test_register_and_login(client):
     })
     assert resp.status_code == 200
     assert "access_token" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_rejects_token_missing_sub(client):
+    """Regression test for issue #7: JWT decode must explicitly require
+    `sub` via options={"require": [...]} so missing claims fail loudly
+    with a PyJWTError instead of sneaking through as a silent KeyError."""
+    secret = get_settings().secret_key
+    token_without_sub = jwt.encode(
+        {
+            # No "sub" claim on purpose
+            "workspace_id": str(uuid4()),
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=60),
+        },
+        secret,
+        algorithm=ALGORITHM,
+    )
+    resp = await client.patch(
+        "/workspace/channels",
+        headers={"Authorization": f"Bearer {token_without_sub}"},
+        json={"delivery_channels": {}},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid token"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_rejects_token_missing_exp(client):
+    """Regression test for issue #7: JWT decode must explicitly require
+    `exp` so tokens without an expiry are rejected at decode time."""
+    secret = get_settings().secret_key
+    token_without_exp = jwt.encode(
+        {
+            "sub": str(uuid4()),
+            "workspace_id": str(uuid4()),
+            # No "exp" claim on purpose
+        },
+        secret,
+        algorithm=ALGORITHM,
+    )
+    resp = await client.patch(
+        "/workspace/channels",
+        headers={"Authorization": f"Bearer {token_without_exp}"},
+        json={"delivery_channels": {}},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid token"


### PR DESCRIPTION
## Summary

Adds `options={\"require\": [\"exp\", \"sub\"]}` to the `jwt.decode` call in `get_current_user` so missing claims fail loudly as PyJWT errors instead of sneaking through as silent KeyError on `payload[\"sub\"]`.

Security hardening, PR #4 reviewer's follow-up.

## Changes

**`backend/app/routers/auth.py`:**
- `jwt.decode` now passes `options={\"require\": [\"exp\", \"sub\"]}`
- Dropped `KeyError` from the `except` tuple — PyJWT raises `MissingRequiredClaimError` (a `PyJWTError` subclass) when a required claim is missing, so the catch is no longer needed

**`backend/tests/test_auth.py`:**
- `test_get_current_user_rejects_token_missing_sub` — hand-crafts a token without `sub` and verifies 401
- `test_get_current_user_rejects_token_missing_exp` — hand-crafts a token without `exp` and verifies 401
- Both hit `/workspace/channels` PATCH which requires `get_current_user`

## Why this matters

Before: an attacker who could produce a valid-signature token without `exp` would get through the signature check. The `KeyError` catch would then catch the missing-`sub` case, but a token with a valid `sub` and no `exp` would never expire. Defense-in-depth rule says: don't rely on implicit catch-alls for security-critical contracts.

After: PyJWT enforces both claims at decode time, before any Python code touches the payload. Explicit > implicit.

## Test baseline

| Before | After |
|---|---|
| 48 pass / 2 fail | **50 pass / 2 fail** |

The 2 remaining failures are pre-existing: issue #6 (Slack router) and issue #11 (test_e2e OpenAI mocking gap).

Closes #7