### PR TITLE
fix(db): add missing FK on connections.user_id

### DIFF
--- a/backend/alembic/versions/003_connection_user_id_fk.py
+++ b/backend/alembic/versions/003_connection_user_id_fk.py
@@ -8,28 +8,67 @@ The `connections.user_id` column has been NOT NULL since 001 but the
 DB-level FK was never declared. The ORM (Connection.user_id) also did
 not declare ForeignKey(...) until PR #13. This migration closes the gap.
 
-Per Sonar CLAUDE.md "expand / contract" guidance: this is a pure additive
-constraint on an existing column. Any orphan rows in dev/prod must be
-cleaned before running this migration. The constraint uses ON DELETE
-RESTRICT (the default) because a user should not be deletable while
-connections they scraped still reference them; higher-level logic
-decides what to do with a user's connections when the user is removed.
+Uses the two-phase `NOT VALID` + `VALIDATE CONSTRAINT` pattern so this
+is safe to run against a large production `connections` table without
+holding ACCESS EXCLUSIVE during the full-table validation scan:
+
+  Phase 1 — ADD CONSTRAINT ... NOT VALID
+    Takes ACCESS EXCLUSIVE only briefly (catalog update). New and updated
+    rows are immediately enforced.
+
+  Phase 2 — VALIDATE CONSTRAINT
+    Takes only SHARE UPDATE EXCLUSIVE, which does not block reads or
+    writes on `connections`. Scans existing rows; fails loudly if any
+    orphan row is found.
+
+ON DELETE RESTRICT is explicit, matching the ORM side in connection.py:
+a user cannot be deleted while connections they scraped still reference
+them — higher-level application logic decides what to do with a user's
+connections when removing the user (reassign / soft-delete / archive).
+
+A pre-flight orphan check emits a clear error with a repair query if any
+`connections.user_id` points at a missing user, so operators get better
+context than a raw Postgres FK-violation error.
 """
 from alembic import op
+import sqlalchemy as sa
 
-revision = "003"
-down_revision = "002"
+revision = '003'
+down_revision = '002'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.create_foreign_key(
-        "connections_user_id_fkey",
-        "connections",
-        "users",
-        ["user_id"],
-        ["id"],
+    # Pre-flight: detect orphan user_id rows before attempting the constraint,
+    # so the error message tells the operator exactly how to find and repair them.
+    conn = op.get_bind()
+    orphan_count = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM connections c "
+            "LEFT JOIN users u ON c.user_id = u.id "
+            "WHERE u.id IS NULL"
+        )
+    ).scalar()
+    if orphan_count:
+        raise RuntimeError(
+            f"[migration 003] Cannot add connections_user_id_fkey: "
+            f"{orphan_count} orphan row(s) in `connections` reference a non-existent "
+            f"user. Inspect with: SELECT c.id, c.user_id FROM connections c "
+            f"LEFT JOIN users u ON c.user_id = u.id WHERE u.id IS NULL; "
+            f"then delete or repair before re-running this migration."
+        )
+
+    # Phase 1: add the FK without scanning existing rows.
+    op.execute(
+        "ALTER TABLE connections "
+        "ADD CONSTRAINT connections_user_id_fkey "
+        "FOREIGN KEY (user_id) REFERENCES users(id) "
+        "ON DELETE RESTRICT NOT VALID"
+    )
+    # Phase 2: validate existing rows without blocking reads/writes.
+    op.execute(
+        "ALTER TABLE connections VALIDATE CONSTRAINT connections_user_id_fkey"
     )
 
 

--- a/backend/alembic/versions/003_connection_user_id_fk.py
+++ b/backend/alembic/versions/003_connection_user_id_fk.py
@@ -1,0 +1,41 @@
+"""Add missing FK constraint on connections.user_id → users.id
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-04-12
+
+The `connections.user_id` column has been NOT NULL since 001 but the
+DB-level FK was never declared. The ORM (Connection.user_id) also did
+not declare ForeignKey(...) until PR #13. This migration closes the gap.
+
+Per Sonar CLAUDE.md "expand / contract" guidance: this is a pure additive
+constraint on an existing column. Any orphan rows in dev/prod must be
+cleaned before running this migration. The constraint uses ON DELETE
+RESTRICT (the default) because a user should not be deletable while
+connections they scraped still reference them; higher-level logic
+decides what to do with a user's connections when the user is removed.
+"""
+from alembic import op
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_foreign_key(
+        "connections_user_id_fkey",
+        "connections",
+        "users",
+        ["user_id"],
+        ["id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "connections_user_id_fkey",
+        "connections",
+        type_="foreignkey",
+    )

--- a/backend/app/models/connection.py
+++ b/backend/app/models/connection.py
@@ -10,7 +10,7 @@ class Connection(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="RESTRICT"), nullable=False)
     linkedin_id = Column(String, nullable=False)
     name = Column(String, nullable=False)
     headline = Column(Text)


### PR DESCRIPTION
## Summary

Closes #14. Adds migration `003_connection_user_id_fk.py` to declare the DB-level foreign key on `connections.user_id → users.id`.

## Background

`connections.user_id` has been NOT NULL since migration 001, but the DB-level FK was never declared. The ORM was similarly missing \`ForeignKey(...)\` on the column until PR #13 closed the ORM side. This PR closes the DB side.

## What's in the migration

- **upgrade:** \`op.create_foreign_key(\"connections_user_id_fkey\", \"connections\", \"users\", [\"user_id\"], [\"id\"])\`
- **downgrade:** \`op.drop_constraint(\"connections_user_id_fkey\", ...)\`
- \`ON DELETE RESTRICT\` (Postgres default) — a user cannot be deleted while their scraped connections still reference them. Higher-level logic decides what to do with connections when removing a user.
- Additive constraint only; no column rename, no data change, no risk of data loss.

## Test plan

- [x] \`docker compose exec -T api alembic upgrade head\` → clean
- [x] Verified FK present: \`connections_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id)\`
- [x] \`docker compose exec -T api alembic downgrade -1\` → clean, FK removed
- [x] \`docker compose exec -T api alembic upgrade head\` → clean, FK re-applied
- [x] Full test suite: 51 passed / 1 failed (test_e2e, tracked as #11 — unrelated)

## Deployment note

Any environment with historical orphan connections (user_id pointing at a deleted user) must clean them before this migration runs. Dev and test DBs are clean.