### PR TITLE
fix(tests): patch embedding_provider at lookup site in profile router

### DIFF
--- a/backend/tests/test_e2e.py
+++ b/backend/tests/test_e2e.py
@@ -46,8 +46,13 @@ async def test_full_pipeline_end_to_end(client):
         "capability_summary": "We build custom AI agents for SaaS automation."
     }'''
 
+    # Patch where the names are looked up, not where they're defined:
+    # `app.routers.profile` does `from app.services.embedding import embedding_provider`
+    # at import time, so patching `app.services.embedding.embedding_provider` does not
+    # affect the router's local binding. Same rule applies to `llm_client` in
+    # `profile_extractor`, which already uses the correct path.
     with patch("app.services.profile_extractor.llm_client") as mock_llm, \
-         patch("app.services.embedding.embedding_provider") as mock_emb:
+         patch("app.routers.profile.embedding_provider") as mock_emb:
         mock_llm.complete = AsyncMock(return_value=mock_profile_json)
         mock_emb.embed = AsyncMock(return_value=[0.5] * 1536)
 


### PR DESCRIPTION
## Summary

Closes #11. \`test_full_pipeline_end_to_end\` was hitting real OpenAI with a placeholder API key and failing with \`AuthenticationError\` because the embedding mock was patched at the wrong import path.

## Root cause

Same pattern as PR #16 (Slack router mock). The test used:

\`\`\`python
patch("app.services.embedding.embedding_provider")
\`\`\`

But \`app.routers.profile:11\` does \`from app.services.embedding import embedding_provider\` at import time, creating its own local binding in the router module. Patching the source module (\`app.services.embedding.embedding_provider\`) does not affect the router's local reference — the router still points at the original \`_LazyEmbeddingProvider\`.

When \`profile.py:42\` called \`embedding_provider.embed(...)\`, it used its local name, which instantiated a real \`OpenAIEmbeddingProvider\` against the placeholder key, triggering the 401.

## Fix

Patch where the name is looked up, not where it's defined:

\`\`\`python
patch("app.routers.profile.embedding_provider")
\`\`\`

The \`llm_client\` patch was already correct (\`app.services.profile_extractor.llm_client\` is the site where \`profile_extractor.py\` looks it up).

Added a comment explaining the rule so future test contributors don't repeat the mistake.

## Test plan

- [x] \`docker compose exec -T api pytest tests/test_e2e.py -v\` → 1 passed
- [x] \`docker compose exec -T api pytest -q\` → **52/52 passed** (first fully-green main since the repo existed)
- [x] No production code changes — only the mock path was wrong

## Rule of thumb

From \`unittest.mock\` docs: *patch where the object is looked up, not where it's defined.* This bug and #6 are the same bug in different clothes. Worth internalizing.