### PR TITLE
refactor(delivery): constructor-inject sender registry into DeliveryRouter

### DIFF
--- a/backend/app/delivery/router.py
+++ b/backend/app/delivery/router.py
@@ -15,6 +15,12 @@ CHANNEL_SENDERS = {
 
 
 class DeliveryRouter:
+    def __init__(self, senders: dict[str, type] | None = None):
+        # Constructor-injected sender registry. Defaults to the module-level
+        # CHANNEL_SENDERS so production call sites stay unchanged. Tests pass
+        # a fake registry directly instead of monkey-patching globals.
+        self._senders = senders if senders is not None else CHANNEL_SENDERS
+
     async def deliver(self, alert, workspace=None, db=None) -> None:
         """
         Fan-out alert to all configured channels that meet the priority threshold.
@@ -36,7 +42,7 @@ class DeliveryRouter:
             min_value = PRIORITY_ORDER.get(min_priority, 1)
 
             if alert_priority_value >= min_value:
-                sender_class = CHANNEL_SENDERS.get(channel_name)
+                sender_class = self._senders.get(channel_name)
                 if sender_class:
                     sender = sender_class()
                     tasks.append(sender.send(alert=alert, workspace=workspace))

--- a/backend/tests/test_delivery_router.py
+++ b/backend/tests/test_delivery_router.py
@@ -1,6 +1,6 @@
 import pytest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 from app.delivery.router import DeliveryRouter
 
@@ -50,13 +50,9 @@ async def test_router_calls_slack_for_configured_workspace():
 
     mock_class, mock_instance = _mock_sender_class()
 
-    # Patch the CHANNEL_SENDERS dict directly. Patching `app.delivery.router.SlackSender`
-    # does NOT work because CHANNEL_SENDERS was populated at import time with a direct
-    # reference to the original SlackSender class — the dict entry doesn't follow
-    # subsequent rebinding of the module-level name.
-    with patch.dict("app.delivery.router.CHANNEL_SENDERS", {"slack": mock_class}):
-        router = DeliveryRouter()
-        await router.deliver(alert=alert, workspace=workspace)
+    # Constructor-inject a fake sender registry — no module-level patching needed.
+    router = DeliveryRouter(senders={"slack": mock_class})
+    await router.deliver(alert=alert, workspace=workspace)
 
     mock_instance.send.assert_called_once()
     # Verify the sender was called with both alert and workspace
@@ -72,8 +68,7 @@ async def test_router_skips_channel_below_min_priority():
 
     mock_class, mock_instance = _mock_sender_class()
 
-    with patch.dict("app.delivery.router.CHANNEL_SENDERS", {"slack": mock_class}):
-        router = DeliveryRouter()
-        await router.deliver(alert=alert, workspace=workspace)
+    router = DeliveryRouter(senders={"slack": mock_class})
+    await router.deliver(alert=alert, workspace=workspace)
 
     mock_instance.send.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #17. Refactors \`DeliveryRouter\` so tests inject the sender registry directly via the constructor instead of monkey-patching \`CHANNEL_SENDERS\` at the module level.

## Motivation

Two test failures in this repo shipped because of \"patch where the name is defined\" bugs:
- **#6 / PR #16** — Slack router test patched \`app.delivery.router.SlackSender\` but \`CHANNEL_SENDERS\` held a direct reference, so the real sender was used.
- **#11 / PR #20** — \`test_e2e\` patched \`app.services.embedding.embedding_provider\` but the router had already imported its own local binding.

Both fixes worked but kept the underlying footgun. Constructor injection removes it entirely for the delivery layer: there's nothing to patch.

## Change

\`\`\`python
class DeliveryRouter:
    def __init__(self, senders: dict[str, type] | None = None):
        self._senders = senders if senders is not None else CHANNEL_SENDERS

    async def deliver(self, alert, workspace=None, db=None) -> None:
        ...
        sender_class = self._senders.get(channel_name)
\`\`\`

Production call site unchanged:
\`\`\`python
# backend/app/workers/pipeline.py:233
await DeliveryRouter().deliver(alert=alert, db=db)  # uses default CHANNEL_SENDERS
\`\`\`

Tests now read:
\`\`\`python
router = DeliveryRouter(senders={\"slack\": mock_class})
await router.deliver(alert=alert, workspace=workspace)
\`\`\`

No more \`patch.dict\`, no more comment about CHANNEL_SENDERS import-time binding.

## Related

FastAPI \`Depends()\` for LLM / embedding providers is a similar pattern, tracked separately as #21. That's the router-layer equivalent; this PR handles the service-layer equivalent for \`DeliveryRouter\`.

## Test plan

- [x] \`docker compose exec -T api pytest tests/test_delivery_router.py -v\` → 2/2 passing
- [x] \`docker compose exec -T api pytest -q\` → 52/52 passing
- [x] Production call site at \`backend/app/workers/pipeline.py:233\` unchanged; uses default CHANNEL_SENDERS via \`DeliveryRouter()\`

## What's not in scope

- #18 (surface \`asyncio.gather\` failures) — next PR in the queue, easier to do once this DI refactor is in place
- #21 (FastAPI Depends for LLM/embedding providers) — related but different layer