### PR TITLE
fix(delivery): log asyncio.gather failures in DeliveryRouter.deliver

### DIFF
--- a/backend/app/delivery/router.py
+++ b/backend/app/delivery/router.py
@@ -1,8 +1,11 @@
 import asyncio
+import logging
 from app.delivery.slack import SlackSender
 from app.delivery.email import EmailSender
 from app.delivery.telegram import TelegramSender
 from app.delivery.whatsapp import WhatsAppSender
+
+logger = logging.getLogger(__name__)
 
 PRIORITY_ORDER = {"high": 3, "medium": 2, "low": 1}
 
@@ -36,6 +39,9 @@ class DeliveryRouter:
         channels = workspace.delivery_channels or {}
         alert_priority_value = PRIORITY_ORDER.get(alert.priority, 1)
 
+        # Track channel names alongside tasks so gather results can be
+        # correlated back to their channel when logging failures.
+        invoked_channels: list[str] = []
         tasks = []
         for channel_name, config in channels.items():
             min_priority = config.get("min_priority", "low")
@@ -46,6 +52,23 @@ class DeliveryRouter:
                 if sender_class:
                     sender = sender_class()
                     tasks.append(sender.send(alert=alert, workspace=workspace))
+                    invoked_channels.append(channel_name)
 
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+        if not tasks:
+            return
+
+        # return_exceptions=True so one failing channel never cancels siblings.
+        # Each result is inspected below and logged if it's an exception, so
+        # failures surface in logs instead of being silently swallowed.
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for channel_name, result in zip(invoked_channels, results):
+            if isinstance(result, Exception):
+                logger.error(
+                    "[DeliveryRouter] Channel send failed: %s. "
+                    "channel=%s alert_id=%s workspace_id=%s",
+                    result,
+                    channel_name,
+                    getattr(alert, "id", None),
+                    getattr(workspace, "id", None),
+                    exc_info=result,
+                )

--- a/backend/tests/test_delivery_router.py
+++ b/backend/tests/test_delivery_router.py
@@ -109,3 +109,7 @@ async def test_router_logs_channel_failure_and_continues_siblings(caplog):
     assert "slack webhook 500" in msg
     assert str(alert.id) in msg
     assert str(workspace.id) in msg
+    # Pin the `exc_info=result` kwarg so a regression that drops it (silently
+    # losing the stack trace in logs) fails loudly instead of sneaking through.
+    assert failure_records[0].exc_info is not None
+    assert failure_records[0].exc_info[1] is slack_instance.send.side_effect

--- a/backend/tests/test_delivery_router.py
+++ b/backend/tests/test_delivery_router.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -72,3 +73,39 @@ async def test_router_skips_channel_below_min_priority():
     await router.deliver(alert=alert, workspace=workspace)
 
     mock_instance.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_router_logs_channel_failure_and_continues_siblings(caplog):
+    """A failing sender must not cancel sibling channels, and its exception
+    must be logged with channel + alert_id + workspace_id context instead of
+    being silently swallowed by asyncio.gather(return_exceptions=True)."""
+    alert = make_alert(priority="high")
+    workspace = SimpleNamespace(
+        id=uuid4(),
+        delivery_channels={
+            "slack": {"webhook_url": "https://hooks.slack.com/test", "min_priority": "low"},
+            "email": {"to": "ops@example.com", "min_priority": "low"},
+        },
+    )
+
+    # Slack raises; email succeeds. Both must be invoked (siblings preserved).
+    slack_class, slack_instance = _mock_sender_class()
+    slack_instance.send = AsyncMock(side_effect=RuntimeError("slack webhook 500"))
+    email_class, email_instance = _mock_sender_class()
+
+    router = DeliveryRouter(senders={"slack": slack_class, "email": email_class})
+
+    with caplog.at_level(logging.ERROR, logger="app.delivery.router"):
+        await router.deliver(alert=alert, workspace=workspace)
+
+    slack_instance.send.assert_called_once()
+    email_instance.send.assert_called_once()
+
+    failure_records = [r for r in caplog.records if r.name == "app.delivery.router"]
+    assert len(failure_records) == 1, "expected exactly one error log for the failing channel"
+    msg = failure_records[0].getMessage()
+    assert "slack" in msg
+    assert "slack webhook 500" in msg
+    assert str(alert.id) in msg
+    assert str(workspace.id) in msg


### PR DESCRIPTION
## Summary

Closes #18. \`DeliveryRouter.deliver\` was calling \`asyncio.gather(*tasks, return_exceptions=True)\` and discarding the results — every exception raised inside a sender's \`.send()\` was silently swallowed with no log, no metric, no breadcrumb. This PR makes failures visible without changing the fan-out semantics.

## Why this matters

This is the systemic weakness that let issue #6 hide for months. The real \`SlackSender\` was raising in the test; \`return_exceptions=True\` swallowed it; the mock's \`send\` was never invoked; \`assert_called_once()\` failed with a confusing "not called" error instead of the actual traceback. Same class of failure would hit production: a misconfigured Slack webhook or an expired Telegram token would silently drop alerts with no oncall signal.

## Change

\`\`\`python
# Track invoked channels alongside tasks so we can correlate gather
# results back to their channel name when logging failures.
invoked_channels: list[str] = []
tasks = []
for channel_name, config in channels.items():
    ...
    if alert_priority_value >= min_value:
        sender_class = self._senders.get(channel_name)
        if sender_class:
            sender = sender_class()
            tasks.append(sender.send(alert=alert, workspace=workspace))
            invoked_channels.append(channel_name)

if not tasks:
    return

# return_exceptions=True is preserved — one failing channel never cancels
# siblings. Only the error visibility changes.
results = await asyncio.gather(*tasks, return_exceptions=True)
for channel_name, result in zip(invoked_channels, results):
    if isinstance(result, Exception):
        logger.error(
            "[DeliveryRouter] Channel send failed: %s. "
            "channel=%s alert_id=%s workspace_id=%s",
            result, channel_name,
            getattr(alert, "id", None),
            getattr(workspace, "id", None),
            exc_info=result,
        )
\`\`\`

- \`return_exceptions=True\` **preserved**. A failing channel must never cancel siblings. This PR only adds visibility.
- Log level is ERROR with \`exc_info=result\` so the full stack trace hits the logs.
- Log format matches the repo's \`error-messages.md\` convention: \`[Module] Operation failed: specific reason. Context: {...}\`.
- Uses stdlib \`logging.getLogger(__name__)\` to match \`app/workers/pipeline.py\`. When \`structlog\` lands (per Sonar CLAUDE.md "Observability — required before launch"), this call site migrates for free.

## Regression test

New test \`test_router_logs_channel_failure_and_continues_siblings\`:
1. Workspace configured for both Slack and Email
2. Slack sender raises \`RuntimeError(\"slack webhook 500\")\`
3. Email sender succeeds
4. Asserts **both** senders were invoked (fan-out preserved)
5. Asserts **exactly one** error record on \`app.delivery.router\`
6. Asserts the log message contains: channel name (\"slack\"), exception message, \`alert.id\`, \`workspace.id\`

This test pins down all three guarantees: fan-out preservation, error logging, and context correlation.

## Test plan

- [x] \`docker compose exec -T api pytest tests/test_delivery_router.py -v\` → 3/3 passing (including the new regression test)
- [x] \`docker compose exec -T api pytest -q\` → **53/53 passing**
- [x] Production call site at \`backend/app/workers/pipeline.py:233\` unchanged

## What's not in scope

- Prometheus counter \`sonar_delivery_failures_total{channel=...}\` — deferred until observability lands per CLAUDE.md
- Migration to \`structlog\` — repo-wide concern, separate effort
- Alerting / oncall paging on delivery failures — higher-level product decision