### PR TITLE
fix(ci): unblock alembic + frontend CI on GitHub Actions

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -22,6 +22,7 @@ if config.config_file_name is not None:
 # environments don't need to match docker-compose's `postgres` service name.
 # Alembic uses psycopg2 (sync); strip `+asyncpg` so the one env var can serve
 # both the async app and sync migrations.
+# NOTE: do not log _env_db_url — it contains the database password.
 _env_db_url = os.environ.get("DATABASE_URL")
 if _env_db_url:
     config.set_main_option(

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -18,6 +18,17 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
+# Let $DATABASE_URL override the hardcoded alembic.ini URL so CI and other
+# environments don't need to match docker-compose's `postgres` service name.
+# Alembic uses psycopg2 (sync); strip `+asyncpg` so the one env var can serve
+# both the async app and sync migrations.
+_env_db_url = os.environ.get("DATABASE_URL")
+if _env_db_url:
+    config.set_main_option(
+        "sqlalchemy.url",
+        _env_db_url.replace("postgresql+asyncpg://", "postgresql://"),
+    )
+
 target_metadata = Base.metadata
 
 def run_migrations_offline() -> None:

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

Two unrelated CI config bugs surfaced by the first real CI run (on PR #44). Neither is a product regression; both are infrastructure issues from when `ci.yml` was first wired up ~6h ago in commit \`d4f7837\`.

## Backend fix — \`fix(ci): make alembic honor DATABASE_URL env var\`

\`backend/alembic.ini\` hardcodes \`sqlalchemy.url = postgresql://sonar:sonar@postgres:5432/sonar\` (the docker-compose service name). GitHub Actions binds the service to localhost, not \`postgres\`, so migrations failed with:

\`\`\`
could not translate host name "postgres" to address: Temporary failure in name resolution
\`\`\`

\`alembic/env.py\` now reads \`\$DATABASE_URL\` when present and overrides the .ini value. Because alembic uses psycopg2 (sync) while the app uses asyncpg (async), the override strips \`postgresql+asyncpg://\` → \`postgresql://\` so one env var serves both code paths.

## Frontend fix — \`fix(ci): add vite-env.d.ts so tsc sees import.meta.env types\`

\`frontend/src/vite-env.d.ts\` was missing (Vite's scaffolder usually generates it). Without it, \`tsc\` fails on \`src/api/client.ts:4\`:

\`\`\`
TS2339: Property 'env' does not exist on type 'ImportMeta'.
\`\`\`

Fix is a single-line \`/// <reference types="vite/client" />\`. Vite's types already ship in \`node_modules/vite/client.d.ts\` — no new dependency.

## Test plan

- [x] \`docker compose exec -T api alembic upgrade head\` — still works in dev (env var resolves to \`postgres\` host via compose network)
- [x] \`cd frontend && npm run build\` — tsc passes, vite builds 88 modules (214kB bundle)
- [ ] CI (this PR) — must go green on backend-test + frontend-build jobs
- [ ] After merge: re-run CI on PR #44 and PR #42; both should go green

## Refs

- CI workflow introduced in \`d4f7837\` (commit, not a PR)
- Failures first observed on PR #44 — \`Backend — tests\` (exit 1) and \`Frontend — tsc + vite build\` (exit 2)