### PR TITLE
chore(release): strip emojis, attach SBOM/extension zip, add trust footer

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -12,16 +12,16 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "changelog-sections": [
-        { "type": "feat", "section": "🚀 Added", "hidden": false },
-        { "type": "fix", "section": "🐛 Fixed", "hidden": false },
-        { "type": "perf", "section": "⚡ Performance", "hidden": false },
-        { "type": "refactor", "section": "🧹 Changed", "hidden": false },
-        { "type": "docs", "section": "📚 Documentation", "hidden": false },
-        { "type": "test", "section": "🧪 Tests", "hidden": false },
-        { "type": "build", "section": "📦 Build", "hidden": false },
-        { "type": "ci", "section": "🔧 CI/CD", "hidden": false },
-        { "type": "chore", "section": "🔧 Chores", "hidden": false },
-        { "type": "revert", "section": "⏪ Reverts", "hidden": false }
+        { "type": "feat", "section": "Added", "hidden": false },
+        { "type": "fix", "section": "Fixed", "hidden": false },
+        { "type": "perf", "section": "Performance", "hidden": false },
+        { "type": "refactor", "section": "Changed", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "test", "section": "Tests", "hidden": false },
+        { "type": "build", "section": "Build", "hidden": false },
+        { "type": "ci", "section": "CI/CD", "hidden": false },
+        { "type": "chore", "section": "Chores", "hidden": false },
+        { "type": "revert", "section": "Reverts", "hidden": false }
       ]
     }
   }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,3 +76,24 @@ jobs:
             "sonar-extension-${{ steps.release.outputs.tag_name }}.zip" \
             "sonar-sbom-${{ steps.release.outputs.tag_name }}.spdx.json" \
             --clobber
+
+      - if: ${{ steps.release.outputs.release_created }}
+        name: Append supply-chain transparency footer to release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          current=$(gh release view "$TAG" --json body -q .body)
+          footer=$(cat <<FOOTER
+
+          ---
+
+          ### Supply-chain transparency
+          - Code ownership: [CODEOWNERS](https://github.com/${REPO}/blob/main/.github/CODEOWNERS)
+          - Security policy: [SECURITY.md](https://github.com/${REPO}/blob/main/SECURITY.md)
+          - SBOM: \`sonar-sbom-${TAG}.spdx.json\` (attached to this release)
+          - Chrome extension bundle: \`sonar-extension-${TAG}.zip\` (attached to this release)
+          FOOTER
+          )
+          gh release edit "$TAG" --notes "${current}${footer}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,6 +83,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag_name }}
           REPO: ${{ github.repository }}
+        # IMPORTANT: the FOOTER terminator below must sit at the SAME column
+        # as the heredoc body lines. YAML's block-scalar strip auto-detects
+        # the indent from the first content line (`current=...`) and strips
+        # that many spaces from EVERY line — so if `current=...` is at
+        # column 10, the FOOTER terminator must also be at column 10 so it
+        # lands at column 0 where bash recognizes it. Any re-indent of ONE
+        # line without matching the others will hang the next release.
+        # Verified with `bash -n` post-YAML-parse in 2026-04-13 session.
         run: |
           current=$(gh release view "$TAG" --json body -q .body)
           footer=$(cat <<FOOTER

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,49 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+      # The steps below run ONLY when release-please actually creates a
+      # release (i.e., on the push that merges the Release PR). They attach
+      # supply-chain transparency artifacts to the GitHub Release:
+      #   - sonar-extension-<tag>.zip  — loadable Chrome MV3 bundle
+      #   - sonar-sbom-<tag>.spdx.json — SPDX SBOM of the repo
+      # Gated on steps.release.outputs.release_created so ordinary pushes
+      # to main (which only update the Release PR, not cut a release)
+      # don't burn CI minutes on asset packaging.
+
+      - if: ${{ steps.release.outputs.release_created }}
+        name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release.outputs.tag_name }}
+
+      - if: ${{ steps.release.outputs.release_created }}
+        name: Package Chrome extension
+        run: |
+          cd extension
+          zip -r "../sonar-extension-${{ steps.release.outputs.tag_name }}.zip" . -x "*.DS_Store" "*.map"
+
+      - if: ${{ steps.release.outputs.release_created }}
+        name: Generate SBOM (SPDX via syft)
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          output-file: sonar-sbom-${{ steps.release.outputs.tag_name }}.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - if: ${{ steps.release.outputs.release_created }}
+        name: Upload assets to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.release.outputs.tag_name }}" \
+            "sonar-extension-${{ steps.release.outputs.tag_name }}.zip" \
+            "sonar-sbom-${{ steps.release.outputs.tag_name }}.spdx.json" \
+            --clobber


### PR DESCRIPTION
## Summary

Three atomic enhancements to the release-please automation. All take effect on the *next* release (none of them modifies the existing v0.2.0 or v0.2.1 releases). No product code touched; `.github/` only.

## Commits

1. **`afc0afb` — Strip emojis from CHANGELOG section headers.**
   `release-please-config.json` section names go from `🚀 Added` / `🐛 Fixed` / etc. to plain `Added` / `Fixed`. Matches Keep a Changelog canonical format and machine-parseability.
2. **`e853e63` — Attach Chrome extension zip + SPDX SBOM as release assets.**
   Adds `id: release` to the release-please-action step. Four new post-release steps (all gated on `steps.release.outputs.release_created`):
   - Checkout the release tag
   - Zip `extension/` → `sonar-extension-<tag>.zip`
   - Generate SBOM via `anchore/sbom-action@v0` → `sonar-sbom-<tag>.spdx.json`
   - Upload both via `gh release upload --clobber`
3. **`aaa75ef` — Append Supply-chain transparency footer to release notes.**
   Fifth post-release step: edits the auto-generated release body via `gh release edit --notes` to append links to CODEOWNERS, SECURITY.md, and the two uploaded assets.

## Why these changes

Moves Sonar closer to trust-signal parity with mainstream open-source projects:
- SBOM satisfies the supply-chain transparency expectation set by EO 14028 and the EU CRA
- Extension zip gives testers/users a canonical downloadable artifact
- CODEOWNERS + SECURITY.md links surface accountability / reporting paths on every release
- Plain CHANGELOG headers improve compatibility with downstream parsers (goreleaser, git-cliff)

## Test plan

- [x] YAML syntax check (workflow) — manually inspected; heredoc + YAML block-scalar indent correctly aligned
- [x] JSON schema check (config) — conforms to release-please's published schema (`$schema` reference preserved)
- [ ] CI (this PR) — backend/frontend/Docker/CodeQL should pass; release-please job should no-op (no release to cut)
- [ ] **Real-world test happens on the NEXT release.** If anything's broken in the post-release steps, it surfaces only when release-please next cuts a version. Reviewer should evaluate whether that deferred-test profile is acceptable given the workflow's gated nature.

## Refs

- Raised from the CHANGELOG/release structural audit in the 2026-04-13 session
- No open issues closed; this is a forward-looking quality improvement

## Rollback note

If any post-release step fails on the next release cut (v0.2.2+), the release tag and auto-generated notes are already published — recovery is manual but non-blocking:

- Missing asset: `gh release upload <tag> <asset> --clobber` from a local checkout at the tag
- Missing footer: `gh release edit <tag> --notes "$(gh release view <tag> --json body -q .body)$(cat footer.md)"`

The release itself is never blocked by these steps.