### PR TITLE
feat(auth): rate limit /workspace/register to 3/min per IP (closes #63 piece 1)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -28,12 +28,15 @@ def create_access_token(user_id: UUID, workspace_id: UUID) -> str:
     payload = {
         "sub": str(user_id),
         "workspace_id": str(workspace_id),
-        "exp": datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+        "exp": datetime.now(timezone.utc)
+        + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
     }
     return jwt.encode(payload, get_settings().secret_key, algorithm=ALGORITHM)
 
 
-async def get_current_user(token: str = Depends(oauth2_scheme), db: AsyncSession = Depends(get_db)) -> User:
+async def get_current_user(
+    token: str = Depends(oauth2_scheme), db: AsyncSession = Depends(get_db)
+) -> User:
     try:
         payload = jwt.decode(
             token,
@@ -43,16 +46,25 @@ async def get_current_user(token: str = Depends(oauth2_scheme), db: AsyncSession
         )
         user_id = UUID(payload["sub"])
     except (jwt.PyJWTError, ValueError):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
     if not user:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
+        )
     return user
 
 
 @workspace_router.post("/register", status_code=201, response_model=WorkspaceResponse)
-async def register(body: WorkspaceRegister, db: AsyncSession = Depends(get_db)):
+@limiter.limit("3/minute")
+async def register(
+    request: Request,  # required by @limiter.limit — slowapi reads it off the signature
+    body: WorkspaceRegister,
+    db: AsyncSession = Depends(get_db),
+):
     existing = await db.execute(select(User).where(User.email == body.email))
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=400, detail="Email already registered")
@@ -65,12 +77,14 @@ async def register(body: WorkspaceRegister, db: AsyncSession = Depends(get_db)):
         workspace_id=workspace.id,
         email=body.email,
         hashed_password=pwd_context.hash(body.password),
-        role="owner"
+        role="owner",
     )
     db.add(user)
     await db.commit()
 
-    return WorkspaceResponse(workspace_id=workspace.id, user_id=user.id, email=user.email)
+    return WorkspaceResponse(
+        workspace_id=workspace.id, user_id=user.id, email=user.email
+    )
 
 
 class ChannelUpdateRequest(BaseModel):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,8 +2,6 @@ import pytest
 import jwt
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
-from httpx import AsyncClient, ASGITransport
-from app.main import app
 from app.config import get_settings
 
 ALGORITHM = "HS256"
@@ -11,19 +9,22 @@ ALGORITHM = "HS256"
 
 @pytest.mark.asyncio
 async def test_register_and_login(client):
-    resp = await client.post("/workspace/register", json={
-        "workspace_name": "Test Agency",
-        "email": "owner@test.com",
-        "password": "testpassword123"
-    })
+    resp = await client.post(
+        "/workspace/register",
+        json={
+            "workspace_name": "Test Agency",
+            "email": "owner@test.com",
+            "password": "testpassword123",
+        },
+    )
     assert resp.status_code == 201
     data = resp.json()
     assert "workspace_id" in data
 
-    resp = await client.post("/auth/token", data={
-        "username": "owner@test.com",
-        "password": "testpassword123"
-    })
+    resp = await client.post(
+        "/auth/token",
+        data={"username": "owner@test.com", "password": "testpassword123"},
+    )
     assert resp.status_code == 200
     assert "access_token" in resp.json()
 
@@ -76,6 +77,43 @@ async def test_get_current_user_rejects_token_missing_exp(client):
 
 
 @pytest.mark.asyncio
+async def test_register_endpoint_rate_limited_to_3_per_minute(client):
+    """Per sonar/CLAUDE.md Security + issue #63: /workspace/register is
+    rate-limited to prevent email-enumeration scraping. Per-IP limit is
+    3/minute. The 4th request within a minute returns 429 regardless of
+    whether the email is unique.
+
+    Enumeration hardening (generic 201-response-on-duplicate) is NOT part
+    of this test — it's a separate, bigger follow-up in #63 Piece 2."""
+    for i in range(3):
+        resp = await client.post(
+            "/workspace/register",
+            json={
+                "workspace_name": f"Reg RL Test {i}",
+                "email": f"rl{i}@test.com",
+                "password": "testpassword123",
+            },
+        )
+        assert (
+            resp.status_code == 201
+        ), f"request {i + 1} of 3 should succeed, got {resp.status_code}"
+
+    resp = await client.post(
+        "/workspace/register",
+        json={
+            "workspace_name": "Reg RL Test 4",
+            "email": "rl4@test.com",
+            "password": "testpassword123",
+        },
+    )
+    assert (
+        resp.status_code == 429
+    ), f"4th request should be rate-limited (429), got {resp.status_code}"
+    assert resp.json() == {"detail": "Too many requests"}
+    assert resp.headers.get("Retry-After") == "60"
+
+
+@pytest.mark.asyncio
 async def test_login_endpoint_rate_limited_to_5_per_minute(client):
     """Per sonar/CLAUDE.md Security: /auth/token is rate-limited to prevent
     credential-stuffing and brute-force attacks. Per-IP limit is 5/minute.
@@ -87,28 +125,37 @@ async def test_login_endpoint_rate_limited_to_5_per_minute(client):
     prove per-IP isolation. Per-IP keying is a property of
     slowapi.util.get_remote_address and is validated by inspection, not here.
     """
-    await client.post("/workspace/register", json={
-        "workspace_name": "Rate Limit Test",
-        "email": "rl@test.com",
-        "password": "testpassword123",
-    })
+    await client.post(
+        "/workspace/register",
+        json={
+            "workspace_name": "Rate Limit Test",
+            "email": "rl@test.com",
+            "password": "testpassword123",
+        },
+    )
 
     for i in range(5):
-        resp = await client.post("/auth/token", data={
+        resp = await client.post(
+            "/auth/token",
+            data={
+                "username": "rl@test.com",
+                "password": "testpassword123",
+            },
+        )
+        assert (
+            resp.status_code == 200
+        ), f"request {i + 1} of 5 should succeed, got {resp.status_code}"
+
+    resp = await client.post(
+        "/auth/token",
+        data={
             "username": "rl@test.com",
             "password": "testpassword123",
-        })
-        assert resp.status_code == 200, (
-            f"request {i + 1} of 5 should succeed, got {resp.status_code}"
-        )
-
-    resp = await client.post("/auth/token", data={
-        "username": "rl@test.com",
-        "password": "testpassword123",
-    })
-    assert resp.status_code == 429, (
-        f"6th request should be rate-limited (429), got {resp.status_code}"
+        },
     )
+    assert (
+        resp.status_code == 429
+    ), f"6th request should be rate-limited (429), got {resp.status_code}"
     # Body must NOT echo slowapi's default policy string; the custom handler
     # returns a generic message so attackers can't calibrate the window.
     assert resp.json() == {"detail": "Too many requests"}


### PR DESCRIPTION
## Summary

Closes Piece 1 of #63 — rate-limit `/workspace/register` to 3/minute per IP. Reuses the slowapi limiter + custom 429 handler from PR #61.

## What this does NOT do

Piece 2 of #63 — close the email-enumeration primitive by returning a generic 201 on duplicate email + sending a confirmation email flow — is a larger product change and stays open as a follow-up on the same issue. This PR only addresses the rate-limiting half.

## Why 3/min (not 5/min like /auth/token)

Legitimate users register at most once per workspace. Repeat attempts from the same IP are enumeration-shaped behavior, not human onboarding. Tighter limit matches the attack surface.

## Test plan

- [x] `docker compose exec -T api pytest -q` → **59/59 pass** (58 baseline + 1 new)
- [x] New test `test_register_endpoint_rate_limited_to_3_per_minute` in `backend/tests/test_auth.py`: 3 successful registers + 4th gets 429 with generic body + `Retry-After: 60` header
- [x] Existing `test_register_and_login` still passes (3/min accommodates the single register it makes)
- [x] Pre-commit ruff + ruff-format + gitleaks all pass on the commit

## Notes

- Pre-commit ran locally for the first time on this commit (installed via `python3 -m pip install --user pre-commit` during PR #64 foundation work) — reformatted a few lines per project ruff config. Included in the commit.