### PR TITLE
feat(wizard): frontend — Tasks 10-12 of Phase 2 Wizard plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,11 @@ Every Phase 2+ contribution aims to meet these. When skipping something, call it
 
 ### LLM and agent discipline — Sonar is LLM-heavy; read carefully
 - **Prompts are code.** Live in `app/prompts/<name>.py`, version-controlled, reviewed on every change. No dynamic string-building into system prompts.
+- **Prompts live in `app/prompts/<name>.py`.** Each prompt module exports `PROMPT_VERSION: str`, a static `SYSTEM_PROMPT`, a `build_user_message(...)` function that composes the user turn (the ONLY place user input is interpolated), and a `RESPONSE_JSON_SCHEMA` for OpenAI Structured Outputs. Every call logs `PROMPT_VERSION` alongside. Bump the version on every content change. First entry under this convention: `app/prompts/propose_signals.py` (Wizard slice, 2026-04-17).
+
 - **`max_tokens` on every LLM call.** No exceptions. Input token count estimated before sending to catch blowup early.
 - **Cost tracked per workspace/feature.** Log `{workspace_id, feature, input_tokens, output_tokens, cost_usd}` on every call. Hard per-workspace daily cap so runaway loops can't eat the budget.
-- **Single routing layer for model selection.** Cheap models (Groq) for bulk work; expensive models (GPT-4o-mini) for critical work. Fallback chains defined explicitly.
+- **Single routing layer for model selection.** Cheap models (Groq) for bulk work; expensive models (`gpt-5.4-mini`) for critical work. Fallback chains defined explicitly. Upgraded from `gpt-4o-mini` on 2026-04-17 as part of the Wizard slice (PR #64). Single routing layer preserved via `OPENAI_MODEL_EXPENSIVE` constant in `app/config.py`. To bump again, edit the constant and update this rule in lockstep.
 - **Prompt injection defense is mandatory.** User-controlled input (LinkedIn post content!) goes in the **user message** position only. Never f-string user input into the system prompt.
 - **LLM output is untrusted.** Parse with Pydantic / strict JSON schemas. Retry on parse failure (budget: 2 retries). Never pass output directly to shell / SQL / file paths without validation.
 - **Structured outputs where supported.** OpenAI `response_format=<PydanticModel>` is the default path.
@@ -430,7 +432,7 @@ git merge main
 - Keyword pre-filter → embedding cosine similarity → 3-dimension combined score (relevance 50%, relationship 30%, timing 20%)
 - Relationship score defaults by connection degree: 1st=0.90, 2nd=0.60, 3rd=0.30 + interaction boost
 - Timing decays linearly over 24 hours
-- HIGH priority (≥0.80) → GPT-4o-mini for outreach drafts
+- HIGH priority (≥0.80) → `gpt-5.4-mini` for outreach drafts
 - MEDIUM/LOW → Groq + Llama-3.3-70B
 - Thresholds are per-workspace tunable via `workspaces.matching_threshold` (default 0.72)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Onboarding } from './pages/Onboarding';
 import { AlertFeed } from './pages/AlertFeed';
 import { OpportunityBoard } from './pages/OpportunityBoard';
 import { Settings } from './pages/Settings';
+import SignalConfig from './pages/SignalConfig';
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const token = localStorage.getItem('sonar_token');
@@ -29,6 +30,7 @@ export default function App() {
         <Route path="/alerts" element={<RequireAuth><Nav /><AlertFeed /></RequireAuth>} />
         <Route path="/board" element={<RequireAuth><Nav /><OpportunityBoard /></RequireAuth>} />
         <Route path="/settings" element={<RequireAuth><Nav /><Settings /></RequireAuth>} />
+        <Route path="/signals/setup" element={<RequireAuth><Nav /><SignalConfig /></RequireAuth>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -38,7 +38,7 @@ export function Onboarding() {
     const url = (form.elements.namedItem('url') as HTMLInputElement).value;
     try {
       await profileAPI.extract({ url });
-      navigate('/alerts');
+      navigate('/signals/setup');
     } catch {
       setError('Failed to extract profile. Check the URL and try again.');
     }

--- a/frontend/src/pages/SignalConfig.test.tsx
+++ b/frontend/src/pages/SignalConfig.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { SignalConfig } from "./SignalConfig";
+
+// Mock the api client so tests don't hit the backend.
+vi.mock("../api/client", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <SignalConfig />
+    </MemoryRouter>,
+  );
+}
+
+describe("SignalConfig wizard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders step 1 with the 'What do you sell?' prompt", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /what do you sell\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/step 1 of 5/i)).toBeInTheDocument();
+  });
+
+  it("disables Next until the textarea has at least 5 characters", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const next = screen.getByRole("button", { name: /next/i });
+    expect(next).toBeDisabled();
+
+    const textarea = screen.getByRole("textbox");
+    await user.type(textarea, "abcd");
+    expect(next).toBeDisabled();
+
+    await user.type(textarea, "e");
+    expect(next).toBeEnabled();
+  });
+
+  it("advances to step 2 (ICP) after clicking Next", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByRole("textbox"), "Fractional CTO services");
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(
+      screen.getByRole("heading", { name: /who's your icp/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/step 2 of 5/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SignalConfig.tsx
+++ b/frontend/src/pages/SignalConfig.tsx
@@ -1,0 +1,344 @@
+// frontend/src/pages/SignalConfig.tsx
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../api/client";
+
+interface ProposedSignal {
+  phrase: string;
+  example_post: string;
+  intent_strength: number;
+}
+
+type SignalStatus = "accepted" | "edited" | "rejected";
+
+interface SignalSelection {
+  proposed: ProposedSignal;
+  status: SignalStatus;
+  edited?: ProposedSignal;
+}
+
+type Step = 1 | 2 | 3 | 4 | 5;
+
+const containerStyle: React.CSSProperties = {
+  maxWidth: 720,
+  margin: "0 auto",
+  padding: "24px 16px",
+};
+
+const h1Style: React.CSSProperties = { fontSize: 24, marginBottom: 8, fontWeight: 600 };
+const helpStyle: React.CSSProperties = { color: "#555", marginBottom: 16 };
+const textareaStyle: React.CSSProperties = {
+  width: "100%",
+  minHeight: 128,
+  padding: 12,
+  border: "1px solid #ccc",
+  borderRadius: 6,
+  fontFamily: "inherit",
+  fontSize: 14,
+  boxSizing: "border-box",
+};
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: 12,
+  border: "1px solid #ccc",
+  borderRadius: 6,
+  fontSize: 14,
+  boxSizing: "border-box",
+};
+const primaryBtn: React.CSSProperties = {
+  background: "#000",
+  color: "#fff",
+  border: "none",
+  borderRadius: 6,
+  padding: "10px 16px",
+  cursor: "pointer",
+  fontSize: 14,
+};
+const secondaryBtn: React.CSSProperties = {
+  background: "#fff",
+  color: "#000",
+  border: "1px solid #ccc",
+  borderRadius: 6,
+  padding: "10px 16px",
+  cursor: "pointer",
+  fontSize: 14,
+};
+const stepCounterStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: "#888",
+  marginBottom: 24,
+};
+const cardStyle: React.CSSProperties = {
+  border: "1px solid #e2e2e2",
+  borderRadius: 8,
+  padding: 16,
+  marginBottom: 12,
+};
+const errorStyle: React.CSSProperties = { color: "#b00020", marginTop: 12 };
+
+export function SignalConfig() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>(1);
+  const [whatYouSell, setWhatYouSell] = useState("");
+  const [icp, setIcp] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [proposalEventId, setProposalEventId] = useState<string | null>(null);
+  const [selections, setSelections] = useState<SignalSelection[]>([]);
+  // userAdded is wired for a future "Add custom signal" UI (Task 11+).
+  // The v1 wizard only surfaces the LLM-proposed signals; leaving the setter
+  // in place means the later UI can be added without refactoring state.
+  const [userAdded] = useState<ProposedSignal[]>([]);
+
+  const handlePropose = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.post("/workspace/signals/propose", {
+        what_you_sell: whatYouSell,
+        icp: icp || null,
+      });
+      setProposalEventId(data.proposal_event_id);
+      setSelections(
+        data.signals.map((s: ProposedSignal) => ({
+          proposed: s,
+          status: "accepted" as const,
+        })),
+      );
+      setStep(4);
+    } catch (e) {
+      const detail =
+        (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setError(detail || "Failed to generate signals. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateStatus = (idx: number, status: SignalStatus) => {
+    setSelections((prev) => {
+      const next = [...prev];
+      next[idx] = { ...next[idx], status };
+      return next;
+    });
+  };
+
+  const updateEdit = (idx: number, field: keyof ProposedSignal, value: string | number) => {
+    setSelections((prev) => {
+      const next = [...prev];
+      const current = next[idx].edited || { ...next[idx].proposed };
+      next[idx] = {
+        ...next[idx],
+        status: "edited",
+        edited: { ...current, [field]: value },
+      };
+      return next;
+    });
+  };
+
+  const handleConfirm = async () => {
+    if (!proposalEventId) return;
+    setLoading(true);
+    setError(null);
+    const accepted: number[] = [];
+    const edited: Array<{
+      proposed_idx: number;
+      final_phrase: string;
+      final_example_post: string;
+      final_intent_strength: number;
+    }> = [];
+    const rejected: number[] = [];
+    selections.forEach((s, idx) => {
+      if (s.status === "accepted") {
+        accepted.push(idx);
+      } else if (s.status === "edited" && s.edited) {
+        edited.push({
+          proposed_idx: idx,
+          final_phrase: s.edited.phrase,
+          final_example_post: s.edited.example_post,
+          final_intent_strength: s.edited.intent_strength,
+        });
+      } else if (s.status === "rejected") {
+        rejected.push(idx);
+      }
+    });
+    try {
+      await api.post("/workspace/signals/confirm", {
+        proposal_event_id: proposalEventId,
+        accepted,
+        edited,
+        rejected,
+        user_added: userAdded,
+      });
+      navigate("/dashboard");
+    } catch (e) {
+      const detail =
+        (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setError(detail || "Failed to save signals.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={containerStyle}>
+      <div style={stepCounterStyle}>Step {step} of 5</div>
+
+      {step === 1 && (
+        <section>
+          <h1 style={h1Style}>What do you sell?</h1>
+          <p style={helpStyle}>
+            In one or two sentences. Example: "Fractional CTO services for Series A-B SaaS
+            startups with small engineering teams."
+          </p>
+          <textarea
+            style={textareaStyle}
+            value={whatYouSell}
+            onChange={(e) => setWhatYouSell(e.target.value)}
+          />
+          <div style={{ marginTop: 16 }}>
+            <button
+              style={primaryBtn}
+              disabled={whatYouSell.trim().length < 5}
+              onClick={() => setStep(2)}
+            >
+              Next
+            </button>
+          </div>
+        </section>
+      )}
+
+      {step === 2 && (
+        <section>
+          <h1 style={h1Style}>Who's your ICP? (optional)</h1>
+          <p style={helpStyle}>
+            Who are the people you sell to? Example: "CEOs and VPs Eng at 20-50 person
+            startups."
+          </p>
+          <input
+            style={inputStyle}
+            value={icp}
+            onChange={(e) => setIcp(e.target.value)}
+          />
+          <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
+            <button style={secondaryBtn} onClick={() => setStep(1)}>
+              Back
+            </button>
+            <button style={primaryBtn} onClick={() => setStep(3)}>
+              Next
+            </button>
+          </div>
+        </section>
+      )}
+
+      {step === 3 && (
+        <section>
+          <h1 style={h1Style}>Generating signals...</h1>
+          <p style={helpStyle}>This takes a few seconds.</p>
+          {!loading && !proposalEventId && (
+            <button style={primaryBtn} onClick={handlePropose}>
+              Generate
+            </button>
+          )}
+          {loading && <div>Thinking...</div>}
+          {error && (
+            <div style={errorStyle}>
+              {error}{" "}
+              <button
+                onClick={handlePropose}
+                style={{
+                  background: "none",
+                  border: "none",
+                  textDecoration: "underline",
+                  color: "#b00020",
+                  cursor: "pointer",
+                  padding: 0,
+                  fontSize: "inherit",
+                }}
+              >
+                Retry
+              </button>
+            </div>
+          )}
+        </section>
+      )}
+
+      {step === 4 && (
+        <section>
+          <h1 style={h1Style}>Review your signals</h1>
+          <p style={helpStyle}>
+            Accept, edit, or reject each one. Add your own if anything's missing.
+          </p>
+          {selections.map((sel, idx) => (
+            <div key={idx} style={cardStyle}>
+              <input
+                style={{ ...inputStyle, fontWeight: 500 }}
+                value={sel.edited?.phrase ?? sel.proposed.phrase}
+                onChange={(e) => updateEdit(idx, "phrase", e.target.value)}
+              />
+              <div
+                style={{
+                  fontSize: 13,
+                  color: "#666",
+                  marginTop: 8,
+                  fontStyle: "italic",
+                }}
+              >
+                "{sel.proposed.example_post}"
+              </div>
+              <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
+                <button
+                  onClick={() => updateStatus(idx, "accepted")}
+                  style={{
+                    ...secondaryBtn,
+                    background: sel.status === "accepted" ? "#d4f7dc" : "#fff",
+                  }}
+                >
+                  Accept
+                </button>
+                <button
+                  onClick={() => updateStatus(idx, "rejected")}
+                  style={{
+                    ...secondaryBtn,
+                    background: sel.status === "rejected" ? "#fad4d4" : "#fff",
+                  }}
+                >
+                  Reject
+                </button>
+              </div>
+            </div>
+          ))}
+          <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
+            <button style={secondaryBtn} onClick={() => setStep(3)}>
+              Back
+            </button>
+            <button style={primaryBtn} onClick={() => setStep(5)}>
+              Next
+            </button>
+          </div>
+        </section>
+      )}
+
+      {step === 5 && (
+        <section>
+          <h1 style={h1Style}>Ready to save?</h1>
+          <p style={helpStyle}>
+            {selections.filter((s) => s.status !== "rejected").length + userAdded.length}{" "}
+            signal(s) will be saved.
+          </p>
+          {error && <div style={errorStyle}>{error}</div>}
+          <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
+            <button style={secondaryBtn} onClick={() => setStep(4)}>
+              Back
+            </button>
+            <button style={primaryBtn} disabled={loading} onClick={handleConfirm}>
+              {loading ? "Saving..." : "Save and open dashboard"}
+            </button>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default SignalConfig;


### PR DESCRIPTION
## Summary

Ships the final 3 tasks of the Phase 2 Wizard plan (`docs/phase-2/implementation-wizard.md`). After this merges, **the Wizard slice is fully complete end-to-end** — new users sign up → land on `/signals/setup` → 5-step wizard → propose → review → confirm → dashboard.

## What's included

- **Task 10** — `frontend/src/pages/SignalConfig.tsx`: single-component 5-step wizard with step-state machine. Uses shared `api` client (JWT injected via interceptor). `userAdded` state wired but read-only pending "Add custom" UI. `Settings.tsx`-style inline styles (Tailwind isn't configured in this frontend; polish is a follow-up). 3 Vitest smoke tests: renders step 1, Next disabled when textarea too short, Next on step 1 advances to step 2.
- **Task 11** — Route `/signals/setup` registered inside `<RequireAuth>` group in `App.tsx`. `Onboarding.tsx` redirect changed from `navigate('/alerts')` → `navigate('/signals/setup')` at the end of the profile-extract step. Surgical — preserves all existing auth + extract logic.
- **Task 12** — `CLAUDE.md` updates: LLM routing rule text bumped `gpt-4o-mini` → `gpt-5.4-mini` (both occurrences), added historical note referencing PR #64 and `OPENAI_MODEL_EXPENSIVE` constant, added `app/prompts/<name>.py` convention bullet citing `propose_signals.py` as first entry.

## Design decisions worth knowing

1. **Shared `api` client, not raw axios** — existing frontend convention. Also fixes token-key inconsistency (plan snippet used `access_token`, app uses `sonar_token`).
2. **Inline styles, not Tailwind** — Tailwind isn't configured; matches existing `Settings.tsx` convention. Styling polish is a follow-up.
3. **`/signals/setup` renders inside the main app nav** (`<RequireAuth>` + `<Nav/>` + page). Full-screen wizard chrome can be a follow-up if desired.
4. **Both "Prompts are code" bullets** kept in CLAUDE.md — one is principle, the other is contract. Minor redundancy, can consolidate in a polish pass.

## Test plan

- [x] `cd frontend && npm run build` — passes, 219.77 KB bundle
- [x] `cd frontend && npm run test:run` — 6/6 pass (3 Settings + 3 SignalConfig)
- [x] `docker compose exec -T api pytest -q` — 81 passed + 3 skipped (unchanged — no backend touched)
- [x] All pre-commit hooks clean on every commit
- [ ] CI run on this PR to confirm E2E Playwright + CodeQL are green

## Commits

- `0b3cfe6` feat(frontend): SignalConfig wizard page — 5 steps, single component
- `059f1b7` feat(frontend): /signals/setup route + onboarding redirect
- `51c55e7` docs(claude): LLM tier = gpt-5.4-mini, add app/prompts/ convention

## Plan completion

Merging this closes out the Phase 2 Wizard plan. All 12 tasks landed across PRs #64, #67, #68, and this one.

## Open follow-ups (filed as issues, not blocking)

- **#65** — Re-activate Playwright register/login E2E specs (.fixme pending real UI selector audit); could add a wizard golden-path E2E at the same time
- **#69** — Wizard `/confirm` P3 robustness nits (duplicate indices, column naming, proposed_idx doc, profile_active placeholder)
- **#62** — uvicorn `--proxy-headers` deploy precondition before prod