### PR TITLE
feat(dashboard): Phase 2 Dashboard — Ranked People List MVP (Tasks 1-11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Every Phase 2+ contribution aims to meet these. When skipping something, call it
 - **Response caching** by hash of `(provider, model, prompt, temperature)`. Embeddings especially — cache by content hash; it's the highest-leverage cost reduction we can make.
 - **Temperature = 0 for classifiers and extractors**, higher (0.5-0.8) for creative tasks (outreach drafts, summaries). Document the choice per prompt.
 - **Human-in-the-loop for high-stakes LLM decisions** — outreach drafts, signal proposals, anything customer-facing needs a review queue.
+- **Incremental aggregation pattern.** Pipeline post-scoring work (updating `person_signal_summary`, Redis counters, etc.) lives in `app/workers/incremental_trending.py` and chains to the end of `pipeline.py`. Target runtime <100 ms per call. Future per-post aggregation features (Ring 3 counters, company rollups) follow the same chain-at-end pattern — do NOT inline new aggregation into `pipeline.py` itself. First entry under this convention: Dashboard slice (session 5, 2026-04-18).
 
 ### Agent workflow — how Claude Code sessions work on this project
 - **Read this file in full at session start.** Everything you need is here. If it's out of date, update it in the same commit as the state change — never "cleanup PR later."

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,10 @@
 # Sonar — TODO
 
-## Resume Here (last updated 2026-04-18, session 4)
+## Resume Here (last updated 2026-04-18, session 5)
 
-**Current state:** clean. `main` HEAD = `ce0f958` (Wizard frontend merge). **81 backend tests pass + 3 skipped + 6 frontend vitest tests pass**, all CI green including E2E Playwright. **1 open PR (#71 release-please `v0.4.0`, auto-drafted — merge to cut release). 4 open issues: #43 (blocked upstream), #62 (uvicorn proxy-headers before prod), #65 (Playwright register/login specs re-activation), #69 (Wizard /confirm P3 polish nits).** Latest release: `v0.3.0` (2026-04-17). `v0.4.0` about to cut on #71 merge.
+**This session (2026-04-18, session 5) shipped the Dashboard Ranked People List MVP.** Next natural move: Backfill slice (Day-One Backfill via Chrome extension + Apify) or the Heatmap follow-up to round out `docs/phase-2/design.md §4.3` Section A. Design work required — no implementation plan exists yet for either.
+
+**Previous session state (session 4):** clean. `main` HEAD = `ce0f958` (Wizard frontend merge). **81 backend tests pass + 3 skipped + 6 frontend vitest tests pass**, all CI green including E2E Playwright. **1 open PR (#71 release-please `v0.4.0`, auto-drafted — merge to cut release). 4 open issues: #43 (blocked upstream), #62 (uvicorn proxy-headers before prod), #65 (Playwright register/login specs re-activation), #69 (Wizard /confirm P3 polish nits).** Latest release: `v0.3.0` (2026-04-17). `v0.4.0` about to cut on #71 merge.
 
 **This session (2026-04-17 → 2026-04-18, session 4) shipped the full Phase 2 Wizard slice end-to-end + testing ladder + misc infra. PRs merged:**
 
@@ -55,13 +57,13 @@ Release (1):
 
 Ingest pipeline, capability profile extraction, signal matching, scoring, alerts, delivery channels (Slack / email / Telegram / WhatsApp), Chrome extension, React dashboard, JWT auth. All 4 known Phase 1 bugs closed; the 5 originally-failing tests are all green; 54/54 on `main`.
 
-### Phase 2 — 2 of 5 slices shipped, 3 remaining
+### Phase 2 — **3 of 5 slices shipped, 2 remaining**
 
 | Slice | Status | What it is |
 |---|---|---|
 | **Foundation** | ✅ Shipped (PR #10) | Migration 002, 4 new ORM models, Ring 1/2 matchers, pipeline refactor, scorer keyword bonus, one-shot backfill script, 24 new tests |
 | **Wizard** | ✅ Shipped session 4 (PRs #64 + #68 + #70) | Signal Configuration Wizard — backend API (`POST /workspace/signals/propose` + `/confirm`, `signal_proposal_events` telemetry, `app/prompts/propose_signals.py` v1, idempotency + role-separation defense) + frontend 5-step `SignalConfig.tsx` at `/signals/setup` + Onboarding redirect. Plan at `docs/phase-2/implementation-wizard.md`, decisions at `docs/phase-2/wizard-decisions.md`. |
-| **Dashboard** | ⬜ Not started | Network Intelligence Dashboard — heatmap of buying intent across the user's network + incremental aggregation pipeline. Depends on Wizard (configurable signals first) — now unblocked. Design reference: `docs/phase-2/design.md §4.3`. No implementation plan yet. |
+| **Dashboard** | ✅ Shipped session 5 (this PR — Ranked People List MVP) | Ranked People List at `/dashboard`. `incremental_trending` Celery task keeps `person_signal_summary` fresh within ~100 ms of each scored post. `GET /workspace/dashboard/people` joins `person_signal_summary + connections + posts + signals`. Frontend polls every 30s with tab-visibility pause + instant refetch on filter change. Threshold slider + 1st/2nd-degree filters. Heatmap (Section A) + Trending Topics (Section C) deferred to follow-up slices. |
 | **Backfill** | ⬜ Not started | Day-One Backfill — Chrome extension + Apify integration to seed the system with historical posts on first install. Depends on Phase 1 extension working + signals to match against (Wizard). |
 | **Discovery** | ⬜ Not started | Ring 3 nightly HDBSCAN clustering for emerging topics + Weekly Digest Email. Most experimental — best built last when there's real data. |
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.routers.profile import router as profile_router
 from app.routers.ingest import router as ingest_router
 from app.routers.alerts import router as alerts_router
 from app.routers.signals import router as signals_router
+from app.routers.dashboard import router as dashboard_router
 
 app = FastAPI(title="Sonar API", version="1.0.0")
 
@@ -43,6 +44,7 @@ app.include_router(profile_router)
 app.include_router(ingest_router)
 app.include_router(alerts_router)
 app.include_router(signals_router)
+app.include_router(dashboard_router)
 
 
 @app.get("/health")

--- a/backend/app/models/connection.py
+++ b/backend/app/models/connection.py
@@ -1,16 +1,31 @@
-from sqlalchemy import Column, String, Float, Boolean, Integer, ARRAY, Text, UniqueConstraint, ForeignKey
+from sqlalchemy import (
+    Column,
+    String,
+    Float,
+    Boolean,
+    Integer,
+    ARRAY,
+    Text,
+    UniqueConstraint,
+    ForeignKey,
+)
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from app.models._types import TIMESTAMPTZ
 import uuid
 from app.database import Base
+
 
 class Connection(Base):
     __tablename__ = "connections"
     __table_args__ = (UniqueConstraint("workspace_id", "linkedin_id"),)
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="RESTRICT"), nullable=False)
+    workspace_id = Column(
+        UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False
+    )
+    user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
     linkedin_id = Column(String, nullable=False)
     name = Column(String, nullable=False)
     headline = Column(Text)
@@ -18,6 +33,7 @@ class Connection(Base):
     company = Column(String)
     seniority = Column(String)
     degree = Column(Integer, nullable=False)
+    mutual_count = Column(Integer, nullable=False, default=0, server_default="0")
     relationship_score = Column(Float, nullable=False, default=0.5)
     has_interacted = Column(Boolean, nullable=False, default=False)
     first_seen_at = Column(TIMESTAMPTZ, nullable=False, server_default="now()")

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+from datetime import datetime, timedelta, timezone
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy import select, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.database import get_db
+from app.models.connection import Connection
+from app.models.person_signal_summary import PersonSignalSummary
+from app.models.post import Post
+from app.models.signal import Signal
+from app.models.user import User
+from app.models.workspace import Workspace
+from app.rate_limit import limiter
+from app.routers.auth import get_current_user
+from app.schemas.dashboard import DashboardPeopleResponse, DashboardPerson
+
+router = APIRouter(prefix="/workspace/dashboard", tags=["dashboard"])
+
+
+def _snippet(content: str, max_chars: int = 200) -> str:
+    if len(content) <= max_chars:
+        return content
+    return content[:max_chars].rsplit(" ", 1)[0] + "…"
+
+
+def _post_url(linkedin_post_id: str | None) -> str | None:
+    if not linkedin_post_id:
+        return None
+    if linkedin_post_id.startswith("http"):
+        return linkedin_post_id
+    if linkedin_post_id.startswith("urn:"):
+        return f"https://www.linkedin.com/feed/update/{linkedin_post_id}/"
+    return f"https://www.linkedin.com/feed/update/urn:li:activity:{linkedin_post_id}/"
+
+
+@router.get("/people", response_model=DashboardPeopleResponse)
+@limiter.limit("30/minute")
+async def get_dashboard_people(
+    request: Request,  # required by @limiter.limit
+    threshold: float | None = Query(None, ge=0.0, le=1.0),
+    relationship: str = Query("1,2"),
+    limit: int = Query(50, ge=1, le=200),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    # Resolve threshold: explicit param > workspace default > 0.65 fallback
+    if threshold is None:
+        ws_result = await db.execute(
+            select(Workspace.matching_threshold).where(
+                Workspace.id == current_user.workspace_id
+            )
+        )
+        threshold = ws_result.scalar_one_or_none() or 0.65
+
+    # Parse relationship filter — "1,2" → [1, 2]
+    try:
+        degrees = sorted({int(x) for x in relationship.split(",") if x.strip()})
+    except ValueError:
+        raise HTTPException(
+            status_code=422,
+            detail="Invalid relationship param; expected comma-separated ints",
+        )
+    if not all(d in (1, 2) for d in degrees):
+        raise HTTPException(
+            status_code=422, detail="relationship degree must be 1 or 2"
+        )
+
+    seven_days_ago = datetime.now(timezone.utc) - timedelta(days=7)
+
+    stmt = (
+        select(
+            PersonSignalSummary,
+            Connection,
+            Post,
+            Signal,
+        )
+        .join(Connection, Connection.id == PersonSignalSummary.connection_id)
+        .outerjoin(Post, Post.id == PersonSignalSummary.recent_post_id)
+        .outerjoin(Signal, Signal.id == PersonSignalSummary.recent_signal_id)
+        .where(
+            and_(
+                PersonSignalSummary.workspace_id == current_user.workspace_id,
+                PersonSignalSummary.aggregate_score >= threshold,
+                PersonSignalSummary.last_signal_at >= seven_days_ago,
+                Connection.degree.in_(degrees),
+            )
+        )
+        .order_by(PersonSignalSummary.aggregate_score.desc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    people = [
+        DashboardPerson(
+            connection_id=conn.id,
+            name=conn.name,
+            title=conn.headline,
+            company=conn.company,
+            relationship_degree=conn.degree,
+            mutual_count=None,
+            aggregate_score=summary.aggregate_score,
+            trend_direction=summary.trend_direction,
+            last_signal_at=summary.last_signal_at,
+            recent_post_snippet=_snippet(post.content) if post else None,
+            matching_signal_phrase=sig.phrase if sig else None,
+            recent_post_url=_post_url(post.linkedin_post_id) if post else None,
+        )
+        for summary, conn, post, sig in rows
+    ]
+
+    return DashboardPeopleResponse(
+        people=people, threshold_used=threshold, total=len(people)
+    )

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import re
 from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select, and_
@@ -23,18 +24,51 @@ def _snippet(content: str, max_chars: int = 200) -> str:
     return content[:max_chars].rsplit(" ", 1)[0] + "…"
 
 
+_LINKEDIN_ACTIVITY_ID_RE = re.compile(r"^\d+$")
+
+
 def _post_url(linkedin_post_id: str | None) -> str | None:
+    """Synthesize a LinkedIn thread URL from a stored post id.
+
+    Returns None when the id is empty or an unrecognized shape — emitting a
+    malformed URL would cause silent 404s in the "View thread" UI, which is
+    worse than hiding the link. Supported shapes:
+      - full http(s) URL: passthrough
+      - urn:li:activity:<digits>: wrap in /feed/update/
+      - <digits>: wrap in /feed/update/urn:li:activity:<digits>
+    """
     if not linkedin_post_id:
         return None
-    if linkedin_post_id.startswith("http"):
+    if linkedin_post_id.startswith(("http://", "https://")):
         return linkedin_post_id
-    if linkedin_post_id.startswith("urn:"):
-        return f"https://www.linkedin.com/feed/update/{linkedin_post_id}/"
-    return f"https://www.linkedin.com/feed/update/urn:li:activity:{linkedin_post_id}/"
+    if linkedin_post_id.startswith("urn:li:activity:"):
+        suffix = linkedin_post_id[len("urn:li:activity:") :]
+        if _LINKEDIN_ACTIVITY_ID_RE.match(suffix):
+            return f"https://www.linkedin.com/feed/update/{linkedin_post_id}/"
+        return None
+    if _LINKEDIN_ACTIVITY_ID_RE.match(linkedin_post_id):
+        return (
+            f"https://www.linkedin.com/feed/update/urn:li:activity:{linkedin_post_id}/"
+        )
+    return None
+
+
+def _workspace_rate_limit_key(request: Request) -> str:
+    """Rate-limit by authenticated workspace (via JWT) rather than IP.
+    Falls back to IP when no Authorization header (unauthenticated requests
+    will 401 anyway, but slowapi keys fire before auth runs)."""
+    auth = request.headers.get("authorization", "")
+    if auth.startswith("Bearer "):
+        # Best-effort extraction. Full verification happens in get_current_user.
+        # Here we just need a stable per-workspace key; using the raw token is
+        # fine since different tokens → different keys, same workspace keyed
+        # identically across tabs.
+        return f"ws-token:{auth[7:57]}"  # first 50 chars is ample entropy
+    return request.client.host if request.client else "anon"
 
 
 @router.get("/people", response_model=DashboardPeopleResponse)
-@limiter.limit("30/minute")
+@limiter.limit("60/minute", key_func=_workspace_rate_limit_key)
 async def get_dashboard_people(
     request: Request,  # required by @limiter.limit
     threshold: float | None = Query(None, ge=0.0, le=1.0),
@@ -43,14 +77,16 @@ async def get_dashboard_people(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    # Resolve threshold: explicit param > workspace default > 0.65 fallback
+    # Resolve threshold: explicit param > workspace default > 0.65 fallback.
+    # Using `is None` (not truthiness) so an explicit 0.0 doesn't collapse to fallback.
     if threshold is None:
         ws_result = await db.execute(
             select(Workspace.matching_threshold).where(
                 Workspace.id == current_user.workspace_id
             )
         )
-        threshold = ws_result.scalar_one_or_none() or 0.65
+        ws_default = ws_result.scalar_one_or_none()
+        threshold = ws_default if ws_default is not None else 0.65
 
     # Parse relationship filter — "1,2" → [1, 2]
     try:
@@ -59,6 +95,10 @@ async def get_dashboard_people(
         raise HTTPException(
             status_code=422,
             detail="Invalid relationship param; expected comma-separated ints",
+        )
+    if not degrees:
+        raise HTTPException(
+            status_code=422, detail="relationship param cannot be empty"
         )
     if not all(d in (1, 2) for d in degrees):
         raise HTTPException(
@@ -98,7 +138,7 @@ async def get_dashboard_people(
             title=conn.headline,
             company=conn.company,
             relationship_degree=conn.degree,
-            mutual_count=None,
+            mutual_count=conn.mutual_count if conn.degree == 2 else None,
             aggregate_score=summary.aggregate_score,
             trend_direction=summary.trend_direction,
             last_signal_at=summary.last_signal_at,

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+from pydantic import BaseModel, Field
+
+
+TrendDirection = Literal["up", "flat", "down"]
+
+
+class DashboardPerson(BaseModel):
+    connection_id: UUID
+    name: str
+    title: str | None
+    company: str | None
+    relationship_degree: int = Field(ge=1, le=2)
+    mutual_count: int | None
+    aggregate_score: float = Field(ge=0, le=1)
+    trend_direction: TrendDirection
+    last_signal_at: datetime
+    recent_post_snippet: str | None
+    matching_signal_phrase: str | None
+    recent_post_url: str | None
+
+
+class DashboardPeopleResponse(BaseModel):
+    people: list[DashboardPerson]
+    threshold_used: float = Field(ge=0, le=1)
+    total: int = Field(ge=0)

--- a/backend/app/workers/incremental_trending.py
+++ b/backend/app/workers/incremental_trending.py
@@ -1,0 +1,112 @@
+"""Incremental aggregation task for the dashboard Ranked People List.
+
+Chains to the end of pipeline.py (see Task 2). For every scored post, updates
+the person_signal_summary row for the post's author so the dashboard list
+reflects the new signal within ~100 ms of scoring. Target runtime per call:
+<100 ms (design.md §5.2).
+
+Call shape is a pure function that takes a db_session so tests can assert
+against the same transaction; the Celery wrapper is a thin delegate.
+"""
+
+from __future__ import annotations
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+from sqlalchemy import select, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.person_signal_summary import PersonSignalSummary
+from app.models.post import Post
+
+
+async def update_person_aggregation(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    connection_id: UUID,
+    post_id: UUID,
+    signal_id: UUID | None,
+    combined_score: float,
+) -> None:
+    """Upsert the PersonSignalSummary for this connection + recompute trend.
+
+    NO-OP if signal_id is None — aggregation tracks matched signals only.
+    """
+    if signal_id is None:
+        return
+
+    result = await db.execute(
+        select(PersonSignalSummary).where(
+            and_(
+                PersonSignalSummary.workspace_id == workspace_id,
+                PersonSignalSummary.connection_id == connection_id,
+            )
+        )
+    )
+    summary = result.scalar_one_or_none()
+
+    now = datetime.now(timezone.utc)
+
+    if summary is None:
+        summary = PersonSignalSummary(
+            workspace_id=workspace_id,
+            connection_id=connection_id,
+            aggregate_score=combined_score,
+            trend_direction=await _trend_direction(
+                db, workspace_id, connection_id, now
+            ),
+            last_signal_at=now,
+            recent_post_id=post_id,
+            recent_signal_id=signal_id,
+        )
+        db.add(summary)
+    else:
+        # MVP: replace score with latest. Rolling-avg is follow-up polish.
+        summary.aggregate_score = combined_score
+        summary.last_signal_at = now
+        summary.recent_post_id = post_id
+        summary.recent_signal_id = signal_id
+        summary.trend_direction = await _trend_direction(
+            db, workspace_id, connection_id, now
+        )
+        summary.updated_at = now
+
+
+async def _trend_direction(
+    db: AsyncSession,
+    workspace_id: UUID,
+    connection_id: UUID,
+    now: datetime,
+) -> str:
+    """Compare matched-post counts for this week vs last week → up / flat / down."""
+    this_week_start = now - timedelta(days=7)
+    last_week_start = now - timedelta(days=14)
+
+    this_week = await db.execute(
+        select(Post.id).where(
+            and_(
+                Post.workspace_id == workspace_id,
+                Post.connection_id == connection_id,
+                Post.matched.is_(True),
+                Post.posted_at >= this_week_start,
+            )
+        )
+    )
+    last_week = await db.execute(
+        select(Post.id).where(
+            and_(
+                Post.workspace_id == workspace_id,
+                Post.connection_id == connection_id,
+                Post.matched.is_(True),
+                Post.posted_at >= last_week_start,
+                Post.posted_at < this_week_start,
+            )
+        )
+    )
+    this_week_count = len(this_week.scalars().all())
+    last_week_count = len(last_week.scalars().all())
+
+    if this_week_count > last_week_count:
+        return "up"
+    if this_week_count < last_week_count:
+        return "down"
+    return "flat"

--- a/backend/app/workers/incremental_trending.py
+++ b/backend/app/workers/incremental_trending.py
@@ -12,7 +12,7 @@ against the same transaction; the Celery wrapper is a thin delegate.
 from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
-from sqlalchemy import select, and_
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.person_signal_summary import PersonSignalSummary
 from app.models.post import Post
@@ -77,33 +77,46 @@ async def _trend_direction(
     connection_id: UUID,
     now: datetime,
 ) -> str:
-    """Compare matched-post counts for this week vs last week → up / flat / down."""
+    """Compare matched-post counts for this week vs last week → up / flat / down.
+
+    Uses COALESCE(posted_at, ingested_at) for the window filter — Apify-backfilled
+    posts sometimes have null posted_at. Without the coalesce, such posts would
+    be silently excluded from trend counts and prolific-but-backfilled people
+    would read as `flat` forever.
+    """
     this_week_start = now - timedelta(days=7)
     last_week_start = now - timedelta(days=14)
 
+    # Coalesce ensures posts with null posted_at still contribute to the window.
+    post_ts = func.coalesce(Post.posted_at, Post.ingested_at)
+
     this_week = await db.execute(
-        select(Post.id).where(
+        select(func.count())
+        .select_from(Post)
+        .where(
             and_(
                 Post.workspace_id == workspace_id,
                 Post.connection_id == connection_id,
                 Post.matched.is_(True),
-                Post.posted_at >= this_week_start,
+                post_ts >= this_week_start,
             )
         )
     )
     last_week = await db.execute(
-        select(Post.id).where(
+        select(func.count())
+        .select_from(Post)
+        .where(
             and_(
                 Post.workspace_id == workspace_id,
                 Post.connection_id == connection_id,
                 Post.matched.is_(True),
-                Post.posted_at >= last_week_start,
-                Post.posted_at < this_week_start,
+                post_ts >= last_week_start,
+                post_ts < this_week_start,
             )
         )
     )
-    this_week_count = len(this_week.scalars().all())
-    last_week_count = len(last_week.scalars().all())
+    this_week_count = this_week.scalar_one()
+    last_week_count = last_week.scalar_one()
 
     if this_week_count > last_week_count:
         return "up"

--- a/backend/app/workers/pipeline.py
+++ b/backend/app/workers/pipeline.py
@@ -263,12 +263,24 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
             matched_signal_id = UUID(ring1_matches[0])
         elif ring2_matches:
             matched_signal_id = UUID(ring2_matches[0]["signal_id"])
-        await run_dashboard_aggregation_hook(
-            db,
-            post_id=post_id,
-            signal_id=matched_signal_id,
-            combined_score=scoring.combined_score,
-        )
+        # Dashboard aggregation must NOT fail the pipeline — alert delivery is
+        # the primary value path. If the hook raises (DB timeout, transient
+        # failure), log and continue; the next scored post for this person
+        # will re-run the aggregation. Without this guard, a hook failure
+        # would leave post.processed_at=None + no alert + no retry — worse
+        # than a skipped aggregation.
+        try:
+            await run_dashboard_aggregation_hook(
+                db,
+                post_id=post_id,
+                signal_id=matched_signal_id,
+                combined_score=scoring.combined_score,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[pipeline] run_dashboard_aggregation_hook failed, continuing: %s",
+                exc,
+            )
 
         # Stage 10: Create alert
         alert = Alert(

--- a/backend/app/workers/pipeline.py
+++ b/backend/app/workers/pipeline.py
@@ -2,11 +2,41 @@ import asyncio
 import logging
 from uuid import UUID
 from app.workers.celery_app import celery_app
+from app.workers.incremental_trending import update_person_aggregation
 
 logger = logging.getLogger(__name__)
 
 
-@celery_app.task(name="app.workers.pipeline.process_post_pipeline", bind=True, max_retries=3)
+async def run_dashboard_aggregation_hook(
+    db,
+    *,
+    post_id,
+    signal_id,
+    combined_score,
+) -> None:
+    """Test-friendly entry point into the dashboard aggregation update.
+
+    Also the call-site used from the real pipeline after scoring completes.
+    `signal_id` may be None — `update_person_aggregation` no-ops in that case.
+    """
+    from sqlalchemy import select
+    from app.models.post import Post
+
+    post_result = await db.execute(select(Post).where(Post.id == post_id))
+    post = post_result.scalar_one()
+    await update_person_aggregation(
+        db,
+        workspace_id=post.workspace_id,
+        connection_id=post.connection_id,
+        post_id=post.id,
+        signal_id=signal_id,
+        combined_score=combined_score,
+    )
+
+
+@celery_app.task(
+    name="app.workers.pipeline.process_post_pipeline", bind=True, max_retries=3
+)
 def process_post_pipeline(self, post_id: str, workspace_id: str):
     """
     Main processing pipeline for a single ingested post.
@@ -49,7 +79,7 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
         result = await db.execute(
             select(CapabilityProfileVersion)
             .where(CapabilityProfileVersion.workspace_id == workspace_id)
-            .where(CapabilityProfileVersion.is_active == True)
+            .where(CapabilityProfileVersion.is_active.is_(True))
         )
         profile = result.scalar_one_or_none()
         if not profile:
@@ -68,7 +98,8 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
         ]
         if any(term in content_lower for term in full_blocklist):
             await db.execute(
-                update(Post).where(Post.id == post_id)
+                update(Post)
+                .where(Post.id == post_id)
                 .values(processed_at=datetime.now(timezone.utc), matched=False)
             )
             await db.commit()
@@ -79,12 +110,18 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
         post_embedding = await embedding_provider.embed(post.content)
 
         # Stage 2: Load active signals
-        signal_rows = (await db.execute(
-            select(Signal).where(
-                Signal.workspace_id == workspace_id,
-                Signal.enabled == True,
+        signal_rows = (
+            (
+                await db.execute(
+                    select(Signal).where(
+                        Signal.workspace_id == workspace_id,
+                        Signal.enabled.is_(True),
+                    )
+                )
             )
-        )).scalars().all()
+            .scalars()
+            .all()
+        )
 
         # Stage 3: Ring 1 — keyword matches
         ring1_matches = match_post_to_ring1_signals(post.content, signal_rows)
@@ -96,7 +133,9 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
 
         # Stage 5: Legacy capability-profile relevance score
         row = await db.execute(
-            text("SELECT embedding::text FROM capability_profile_versions WHERE id = :id"),
+            text(
+                "SELECT embedding::text FROM capability_profile_versions WHERE id = :id"
+            ),
             {"id": str(profile.id)},
         )
         emb_str = row.scalar_one_or_none()
@@ -109,10 +148,13 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
             logger.warning(
                 "pipeline_skipped_missing_capability_embedding "
                 "workspace_id=%s profile_id=%s post_id=%s",
-                workspace_id, profile.id, post_id,
+                workspace_id,
+                profile.id,
+                post_id,
             )
             await db.execute(
-                update(Post).where(Post.id == post_id)
+                update(Post)
+                .where(Post.id == post_id)
                 .values(processed_at=datetime.now(timezone.utc), matched=False)
             )
             await db.commit()
@@ -136,7 +178,9 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
             {"e": post_emb_str, "id": str(post_id)},
         )
         await db.execute(
-            update(Post).where(Post.id == post_id).values(
+            update(Post)
+            .where(Post.id == post_id)
+            .values(
                 ring1_matches=ring1_matches,
                 ring2_matches=ring2_matches,
                 relevance_score=relevance_score,
@@ -147,7 +191,8 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
         if connection is None:
             # Orphan post — can't score relationship dimension, mark processed
             await db.execute(
-                update(Post).where(Post.id == post_id)
+                update(Post)
+                .where(Post.id == post_id)
                 .values(processed_at=datetime.now(timezone.utc), matched=False)
             )
             await db.commit()
@@ -165,7 +210,9 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
         threshold = workspace.matching_threshold or 0.72
         if scoring.combined_score < threshold:
             await db.execute(
-                update(Post).where(Post.id == post_id).values(
+                update(Post)
+                .where(Post.id == post_id)
+                .values(
                     processed_at=datetime.now(timezone.utc),
                     matched=False,
                     relevance_score=scoring.relevance_score,
@@ -192,7 +239,9 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
 
         # Stage 9: Persist themes + final scores
         await db.execute(
-            update(Post).where(Post.id == post_id).values(
+            update(Post)
+            .where(Post.id == post_id)
+            .values(
                 processed_at=datetime.now(timezone.utc),
                 matched=True,
                 relevance_score=scoring.relevance_score,
@@ -201,6 +250,24 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
                 combined_score=scoring.combined_score,
                 themes=context.themes,
             )
+        )
+
+        # Dashboard hook — keep person_signal_summary fresh within ~100 ms of
+        # scoring (design.md §5.2). Pick the best matched signal: Ring 1
+        # (keyword) wins over Ring 2 (semantic). `ring1_matches` is a list of
+        # signal-id strings; `ring2_matches` is a list of dicts with
+        # `signal_id`/`similarity`. `update_person_aggregation` no-ops when
+        # signal_id is None.
+        matched_signal_id = None
+        if ring1_matches:
+            matched_signal_id = UUID(ring1_matches[0])
+        elif ring2_matches:
+            matched_signal_id = UUID(ring2_matches[0]["signal_id"])
+        await run_dashboard_aggregation_hook(
+            db,
+            post_id=post_id,
+            signal_id=matched_signal_id,
+            combined_score=scoring.combined_score,
         )
 
         # Stage 10: Create alert

--- a/backend/tests/test_dashboard_endpoint.py
+++ b/backend/tests/test_dashboard_endpoint.py
@@ -1,0 +1,175 @@
+import pytest
+from datetime import datetime, timezone
+from app.models.workspace import Workspace
+from app.models.user import User
+from app.models.connection import Connection
+from app.models.person_signal_summary import PersonSignalSummary
+from app.models.signal import Signal
+from app.models.post import Post
+
+
+async def _seed_person(db_session, *, workspace_name, email, score, degree=1):
+    workspace = Workspace(name=workspace_name)
+    db_session.add(workspace)
+    await db_session.flush()
+    user = User(
+        workspace_id=workspace.id,
+        email=email,
+        hashed_password="x",
+        role="owner",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    conn = Connection(
+        workspace_id=workspace.id,
+        user_id=user.id,
+        linkedin_id=f"li-{email}",
+        name=f"Person {email}",
+        headline="VP Engineering",
+        company="Acme",
+        degree=degree,
+    )
+    db_session.add(conn)
+    await db_session.flush()
+    signal = Signal(
+        workspace_id=workspace.id,
+        phrase="struggling to hire",
+        example_post="example body text",
+        intent_strength=0.7,
+        embedding=[0.0] * 1536,
+        enabled=True,
+    )
+    db_session.add(signal)
+    await db_session.flush()
+    post = Post(
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        linkedin_post_id=f"p-{email}",
+        content="We've been interviewing for 4 months.",
+        post_type="text",
+        source="feed",
+        combined_score=score,
+        matched=True,
+    )
+    db_session.add(post)
+    await db_session.flush()
+    summary = PersonSignalSummary(
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        aggregate_score=score,
+        trend_direction="up",
+        last_signal_at=datetime.now(timezone.utc),
+        recent_post_id=post.id,
+        recent_signal_id=signal.id,
+    )
+    db_session.add(summary)
+    await db_session.commit()
+    return workspace, conn, user
+
+
+def _make_token(user_id, workspace_id):
+    """Helper: forge a JWT for the seeded user so the test doesn't need
+    to re-register (which would create a different workspace)."""
+    from app.routers.auth import create_access_token
+
+    return create_access_token(user_id=user_id, workspace_id=workspace_id)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_people_returns_ranked_list(client, db_session):
+    workspace, conn, user = await _seed_person(
+        db_session,
+        workspace_name="Test Agency",
+        email="dash@a.com",
+        score=0.85,
+        degree=1,
+    )
+    hdrs = {"Authorization": f"Bearer {_make_token(user.id, workspace.id)}"}
+
+    resp = await client.get("/workspace/dashboard/people", headers=hdrs)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert len(body["people"]) == 1
+    row = body["people"][0]
+    assert row["name"].startswith("Person ")
+    assert row["aggregate_score"] == pytest.approx(0.85)
+    assert row["relationship_degree"] == 1
+    assert row["matching_signal_phrase"] == "struggling to hire"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_people_filters_by_threshold(client, db_session):
+    workspace, conn, user = await _seed_person(
+        db_session,
+        workspace_name="Threshold Test",
+        email="thr@a.com",
+        score=0.5,
+        degree=1,
+    )
+    hdrs = {"Authorization": f"Bearer {_make_token(user.id, workspace.id)}"}
+
+    # Threshold 0.65 excludes the 0.5 score
+    resp = await client.get("/workspace/dashboard/people?threshold=0.65", headers=hdrs)
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+    # Threshold 0.4 includes it
+    resp = await client.get("/workspace/dashboard/people?threshold=0.4", headers=hdrs)
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_dashboard_people_filters_by_relationship(client, db_session):
+    workspace, conn, user = await _seed_person(
+        db_session,
+        workspace_name="Rel Test",
+        email="rel@a.com",
+        score=0.9,
+        degree=2,
+    )
+    hdrs = {"Authorization": f"Bearer {_make_token(user.id, workspace.id)}"}
+
+    # Only 1st degree — excludes the 2nd-degree seed
+    resp = await client.get("/workspace/dashboard/people?relationship=1", headers=hdrs)
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+    # 2nd degree only — includes it
+    resp = await client.get("/workspace/dashboard/people?relationship=2", headers=hdrs)
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_dashboard_people_workspace_isolation(client, db_session):
+    # Seed workspace A with a person
+    workspace_a, conn_a, user_a = await _seed_person(
+        db_session,
+        workspace_name="A",
+        email="a@a.com",
+        score=0.9,
+    )
+    # Seed workspace B with a different person
+    workspace_b, conn_b, user_b = await _seed_person(
+        db_session,
+        workspace_name="B",
+        email="b@b.com",
+        score=0.9,
+    )
+
+    hdrs_a = {"Authorization": f"Bearer {_make_token(user_a.id, workspace_a.id)}"}
+
+    resp = await client.get("/workspace/dashboard/people", headers=hdrs_a)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    # The one person we see MUST be from workspace A
+    assert body["people"][0]["connection_id"] == str(conn_a.id)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_people_rejects_unauthenticated(client):
+    resp = await client.get("/workspace/dashboard/people")
+    assert resp.status_code == 401

--- a/backend/tests/test_dashboard_flow.py
+++ b/backend/tests/test_dashboard_flow.py
@@ -1,0 +1,164 @@
+import pytest
+import json
+from sqlalchemy import select
+from app.main import app
+from app.services.llm import get_llm_client
+from app.services.embedding import get_embedding_provider
+from app.models.connection import Connection
+from app.models.user import User
+from app.models.signal import Signal
+from app.models.post import Post
+from app.workers.incremental_trending import update_person_aggregation
+
+
+class FakeLLM:
+    async def complete(self, prompt, model, **kwargs):
+        return json.dumps(
+            {
+                "signals": [
+                    {
+                        "phrase": "hiring struggles",
+                        "example_post": "still interviewing body",
+                        "intent_strength": 0.8,
+                    },
+                    {
+                        "phrase": "fundraising mode",
+                        "example_post": "raising a Series A body",
+                        "intent_strength": 0.7,
+                    },
+                    {
+                        "phrase": "infra pain",
+                        "example_post": "legacy ETL bottlenecks body",
+                        "intent_strength": 0.7,
+                    },
+                    {
+                        "phrase": "team scaling",
+                        "example_post": "hiring plan this quarter body",
+                        "intent_strength": 0.6,
+                    },
+                    {
+                        "phrase": "tech debt",
+                        "example_post": "refactoring payments body",
+                        "intent_strength": 0.6,
+                    },
+                    {
+                        "phrase": "migration pain",
+                        "example_post": "moving off legacy stack body",
+                        "intent_strength": 0.6,
+                    },
+                    {
+                        "phrase": "compliance ask",
+                        "example_post": "SOC2 prep this year body",
+                        "intent_strength": 0.5,
+                    },
+                    {
+                        "phrase": "tooling chaos",
+                        "example_post": "too many SaaS tools body",
+                        "intent_strength": 0.5,
+                    },
+                ]
+            }
+        )
+
+
+class FakeEmbed:
+    async def embed(self, text):
+        return [0.1] * 1536
+
+
+@pytest.mark.asyncio
+async def test_full_flow_register_wizard_pipeline_dashboard(client, db_session):
+    app.dependency_overrides[get_llm_client] = lambda: FakeLLM()
+    app.dependency_overrides[get_embedding_provider] = lambda: FakeEmbed()
+
+    await client.post(
+        "/workspace/register",
+        json={
+            "workspace_name": "End-to-End Agency",
+            "email": "e2e@dash.com",
+            "password": "pass123",
+        },
+    )
+    tok = (
+        await client.post(
+            "/auth/token",
+            data={"username": "e2e@dash.com", "password": "pass123"},
+        )
+    ).json()["access_token"]
+    hdrs = {"Authorization": f"Bearer {tok}"}
+
+    # Complete the wizard
+    propose = (
+        await client.post(
+            "/workspace/signals/propose",
+            json={"what_you_sell": "CTO services"},
+            headers=hdrs,
+        )
+    ).json()
+    confirm = (
+        await client.post(
+            "/workspace/signals/confirm",
+            json={
+                "proposal_event_id": propose["proposal_event_id"],
+                "accepted": [0, 1, 2],
+            },
+            headers=hdrs,
+        )
+    ).json()
+    assert len(confirm["signal_ids"]) == 3
+
+    # Now seed a connection + scored post, and invoke the aggregation
+    # directly (Celery chain would do this in prod — simulating here).
+    user = (
+        await db_session.execute(select(User).where(User.email == "e2e@dash.com"))
+    ).scalar_one()
+    first_signal = (
+        await db_session.execute(
+            select(Signal).where(Signal.workspace_id == user.workspace_id).limit(1)
+        )
+    ).scalar_one()
+    conn = Connection(
+        workspace_id=user.workspace_id,
+        user_id=user.id,
+        linkedin_id="li-e2e",
+        name="Dashboard Test Person",
+        headline="CTO",
+        company="TestCo",
+        degree=1,
+    )
+    db_session.add(conn)
+    await db_session.flush()
+    post = Post(
+        workspace_id=user.workspace_id,
+        connection_id=conn.id,
+        linkedin_post_id="e2e-post-1",
+        content="We've been interviewing senior engineers for 4 months.",
+        post_type="text",
+        source="feed",
+        combined_score=0.88,
+        matched=True,
+    )
+    db_session.add(post)
+    await db_session.commit()
+
+    await update_person_aggregation(
+        db_session,
+        workspace_id=user.workspace_id,
+        connection_id=conn.id,
+        post_id=post.id,
+        signal_id=first_signal.id,
+        combined_score=0.88,
+    )
+    await db_session.commit()
+
+    resp = await client.get("/workspace/dashboard/people", headers=hdrs)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    row = body["people"][0]
+    assert row["name"] == "Dashboard Test Person"
+    assert row["aggregate_score"] == pytest.approx(0.88)
+    assert row["recent_post_snippet"].startswith("We've been interviewing")
+
+    app.dependency_overrides.pop(get_llm_client, None)
+    app.dependency_overrides.pop(get_embedding_provider, None)

--- a/backend/tests/test_dashboard_schemas.py
+++ b/backend/tests/test_dashboard_schemas.py
@@ -1,0 +1,82 @@
+import pytest
+from uuid import uuid4
+from datetime import datetime, timezone
+from pydantic import ValidationError
+from app.schemas.dashboard import DashboardPerson, DashboardPeopleResponse
+
+
+def test_dashboard_person_accepts_minimum_fields():
+    p = DashboardPerson(
+        connection_id=uuid4(),
+        name="Jane Doe",
+        title=None,
+        company=None,
+        relationship_degree=1,
+        mutual_count=None,
+        aggregate_score=0.82,
+        trend_direction="up",
+        last_signal_at=datetime.now(timezone.utc),
+        recent_post_snippet=None,
+        matching_signal_phrase=None,
+        recent_post_url=None,
+    )
+    assert p.relationship_degree == 1
+
+
+def test_relationship_degree_must_be_1_or_2():
+    with pytest.raises(ValidationError):
+        DashboardPerson(
+            connection_id=uuid4(),
+            name="X",
+            title=None,
+            company=None,
+            relationship_degree=3,
+            mutual_count=None,
+            aggregate_score=0.5,
+            trend_direction="flat",
+            last_signal_at=datetime.now(timezone.utc),
+            recent_post_snippet=None,
+            matching_signal_phrase=None,
+            recent_post_url=None,
+        )
+
+
+def test_trend_direction_enum():
+    with pytest.raises(ValidationError):
+        DashboardPerson(
+            connection_id=uuid4(),
+            name="X",
+            title=None,
+            company=None,
+            relationship_degree=1,
+            mutual_count=None,
+            aggregate_score=0.5,
+            trend_direction="sideways",
+            last_signal_at=datetime.now(timezone.utc),
+            recent_post_snippet=None,
+            matching_signal_phrase=None,
+            recent_post_url=None,
+        )
+
+
+def test_aggregate_score_bounds():
+    with pytest.raises(ValidationError):
+        DashboardPerson(
+            connection_id=uuid4(),
+            name="X",
+            title=None,
+            company=None,
+            relationship_degree=1,
+            mutual_count=None,
+            aggregate_score=1.5,
+            trend_direction="flat",
+            last_signal_at=datetime.now(timezone.utc),
+            recent_post_snippet=None,
+            matching_signal_phrase=None,
+            recent_post_url=None,
+        )
+
+
+def test_response_shape():
+    r = DashboardPeopleResponse(people=[], threshold_used=0.65, total=0)
+    assert r.total == 0

--- a/backend/tests/test_incremental_trending.py
+++ b/backend/tests/test_incremental_trending.py
@@ -1,0 +1,156 @@
+import pytest
+from sqlalchemy import select
+from app.models.connection import Connection
+from app.models.post import Post
+from app.models.signal import Signal
+from app.models.person_signal_summary import PersonSignalSummary
+from app.models.workspace import Workspace
+from app.models.user import User
+from app.workers.incremental_trending import update_person_aggregation
+
+
+async def _seed(db_session):
+    workspace = Workspace(name="WS")
+    db_session.add(workspace)
+    await db_session.flush()
+    user = User(
+        workspace_id=workspace.id,
+        email="x@x.com",
+        hashed_password="x",
+        role="owner",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    conn = Connection(
+        workspace_id=workspace.id,
+        user_id=user.id,
+        linkedin_id="li-1",
+        name="Jane",
+        degree=1,
+    )
+    db_session.add(conn)
+    await db_session.flush()
+    signal = Signal(
+        workspace_id=workspace.id,
+        phrase="struggling to hire",
+        example_post="example body text",
+        intent_strength=0.7,
+        embedding=[0.0] * 1536,
+        enabled=True,
+    )
+    db_session.add(signal)
+    await db_session.flush()
+    return workspace, conn, signal
+
+
+@pytest.mark.asyncio
+async def test_update_creates_summary_if_missing(db_session):
+    workspace, conn, signal = await _seed(db_session)
+    post = Post(
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        linkedin_post_id="p-1",
+        content="we've been interviewing",
+        post_type="text",
+        source="feed",
+        combined_score=0.82,
+        matched=True,
+    )
+    db_session.add(post)
+    await db_session.commit()
+
+    await update_person_aggregation(
+        db_session,
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        post_id=post.id,
+        signal_id=signal.id,
+        combined_score=0.82,
+    )
+    await db_session.commit()
+
+    result = await db_session.execute(
+        select(PersonSignalSummary).where(PersonSignalSummary.connection_id == conn.id)
+    )
+    summary = result.scalar_one()
+    assert summary.aggregate_score == pytest.approx(0.82)
+    assert summary.recent_post_id == post.id
+    assert summary.recent_signal_id == signal.id
+    assert summary.trend_direction in {"up", "flat", "down"}
+
+
+@pytest.mark.asyncio
+async def test_update_bumps_existing_summary(db_session):
+    workspace, conn, signal = await _seed(db_session)
+    existing = PersonSignalSummary(
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        aggregate_score=0.5,
+        trend_direction="flat",
+    )
+    db_session.add(existing)
+
+    post = Post(
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        linkedin_post_id="p-2",
+        content="hiring struggles",
+        post_type="text",
+        source="feed",
+        combined_score=0.9,
+        matched=True,
+    )
+    db_session.add(post)
+    await db_session.commit()
+
+    await update_person_aggregation(
+        db_session,
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        post_id=post.id,
+        signal_id=signal.id,
+        combined_score=0.9,
+    )
+    await db_session.commit()
+
+    result = await db_session.execute(
+        select(PersonSignalSummary).where(PersonSignalSummary.connection_id == conn.id)
+    )
+    summary = result.scalar_one()
+    # New score replaces old (simple replacement strategy for MVP; rolling
+    # average is follow-up polish).
+    assert summary.aggregate_score == pytest.approx(0.9)
+    assert summary.recent_post_id == post.id
+
+
+@pytest.mark.asyncio
+async def test_update_with_no_signal_match_is_noop(db_session):
+    workspace, conn, _ = await _seed(db_session)
+    post = Post(
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        linkedin_post_id="p-3",
+        content="random post",
+        post_type="text",
+        source="feed",
+        combined_score=0.1,
+        matched=False,
+    )
+    db_session.add(post)
+    await db_session.commit()
+
+    # signal_id=None means no signal matched; aggregation should NOT create a row
+    await update_person_aggregation(
+        db_session,
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        post_id=post.id,
+        signal_id=None,
+        combined_score=0.1,
+    )
+    await db_session.commit()
+
+    result = await db_session.execute(
+        select(PersonSignalSummary).where(PersonSignalSummary.connection_id == conn.id)
+    )
+    assert result.scalar_one_or_none() is None

--- a/backend/tests/test_pipeline_dashboard_hook.py
+++ b/backend/tests/test_pipeline_dashboard_hook.py
@@ -1,0 +1,73 @@
+import pytest
+from sqlalchemy import select
+from app.models.workspace import Workspace
+from app.models.user import User
+from app.models.connection import Connection
+from app.models.signal import Signal
+from app.models.post import Post
+from app.models.person_signal_summary import PersonSignalSummary
+from app.workers import pipeline as pipeline_module
+
+
+@pytest.mark.asyncio
+async def test_pipeline_populates_person_signal_summary(db_session):
+    """After scoring, pipeline must call update_person_aggregation so the
+    dashboard's PersonSignalSummary stays fresh within ~100 ms (design §5.2)."""
+    workspace = Workspace(name="WS")
+    db_session.add(workspace)
+    await db_session.flush()
+    user = User(
+        workspace_id=workspace.id,
+        email="x@x.com",
+        hashed_password="x",
+        role="owner",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    conn = Connection(
+        workspace_id=workspace.id,
+        user_id=user.id,
+        linkedin_id="li-1",
+        name="Jane",
+        degree=1,
+    )
+    db_session.add(conn)
+    await db_session.flush()
+    signal = Signal(
+        workspace_id=workspace.id,
+        phrase="struggling to hire",
+        example_post="example body text",
+        intent_strength=0.7,
+        embedding=[0.0] * 1536,
+        enabled=True,
+    )
+    db_session.add(signal)
+    await db_session.flush()
+    post = Post(
+        workspace_id=workspace.id,
+        connection_id=conn.id,
+        linkedin_post_id="p-1",
+        content="we've been interviewing",
+        post_type="text",
+        source="feed",
+        combined_score=0.85,
+        matched=True,
+    )
+    db_session.add(post)
+    await db_session.commit()
+
+    await pipeline_module.run_dashboard_aggregation_hook(
+        db_session,
+        post_id=post.id,
+        signal_id=signal.id,
+        combined_score=0.85,
+    )
+    await db_session.commit()
+
+    result = await db_session.execute(
+        select(PersonSignalSummary).where(PersonSignalSummary.connection_id == conn.id)
+    )
+    summary = result.scalar_one()
+    assert summary.aggregate_score == pytest.approx(0.85)
+    assert summary.recent_post_id == post.id
+    assert summary.recent_signal_id == signal.id

--- a/e2e/tests/dashboard-golden-path.spec.ts
+++ b/e2e/tests/dashboard-golden-path.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Dashboard golden-path E2E: register → wizard → dashboard.
+ *
+ * Uses the Playwright `request` context to seed the DB via API (faster +
+ * more stable than UI-clicking the wizard), then navigates the browser
+ * to /dashboard and asserts the ranked list renders.
+ *
+ * Marked `.fixme` until the surrounding register/login E2E specs are
+ * de-fixmed (issue #65) — this test shares their UI assumptions and will
+ * break for the same reasons.
+ */
+import { test, expect } from "@playwright/test";
+
+function uniqueEmail() {
+  return `dash-e2e-${Date.now()}@sonar-e2e.local`;
+}
+
+test.fixme("user can register, complete wizard, and see the dashboard", async ({ page, request }) => {
+  const email = uniqueEmail();
+  const password = "pass123";
+  const backend = process.env.SONAR_BACKEND_URL || "http://localhost:8000";
+
+  // Register via API
+  const reg = await request.post(`${backend}/workspace/register`, {
+    data: { workspace_name: "Dashboard E2E", email, password },
+  });
+  expect(reg.status()).toBe(201);
+
+  // Log in via UI
+  await page.goto("/login");
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByRole("button", { name: /login|sign in|log in/i }).click();
+  await expect(page).not.toHaveURL(/\/login$/, { timeout: 10_000 });
+
+  // Expect to be routed to the wizard
+  await expect(page).toHaveURL(/\/signals\/setup/, { timeout: 10_000 });
+
+  // Fill the wizard minimally and confirm
+  await page.getByRole("textbox").first().fill("Fractional CTO services");
+  await page.getByRole("button", { name: /next/i }).click();
+  // Step 2 (ICP) — skip
+  await page.getByRole("button", { name: /next/i }).click();
+  // Step 3 — click Generate
+  await page.getByRole("button", { name: /generate/i }).click();
+  // Wait for proposal response
+  await page.waitForURL(/\/signals\/setup/, { timeout: 30_000 });
+  // Step 4 — click Next
+  await page.getByRole("button", { name: /next/i }).click();
+  // Step 5 — Save
+  await page.getByRole("button", { name: /save and open dashboard/i }).click();
+
+  // Expect to land on /dashboard
+  await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
+
+  // At minimum, the dashboard renders its header
+  await expect(page.getByText(/network intelligence/i)).toBeVisible({ timeout: 5_000 });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { AlertFeed } from './pages/AlertFeed';
 import { OpportunityBoard } from './pages/OpportunityBoard';
 import { Settings } from './pages/Settings';
 import SignalConfig from './pages/SignalConfig';
+import NetworkIntelligenceDashboard from './pages/NetworkIntelligenceDashboard';
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const token = localStorage.getItem('sonar_token');
@@ -31,6 +32,7 @@ export default function App() {
         <Route path="/board" element={<RequireAuth><Nav /><OpportunityBoard /></RequireAuth>} />
         <Route path="/settings" element={<RequireAuth><Nav /><Settings /></RequireAuth>} />
         <Route path="/signals/setup" element={<RequireAuth><Nav /><SignalConfig /></RequireAuth>} />
+        <Route path="/dashboard" element={<RequireAuth><Nav /><NetworkIntelligenceDashboard /></RequireAuth>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/hooks/usePolledEndpoint.test.ts
+++ b/frontend/src/hooks/usePolledEndpoint.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { usePolledEndpoint } from "./usePolledEndpoint";
+
+describe("usePolledEndpoint", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls fetcher once on mount and exposes loading + data", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ hello: "world" });
+    const { result } = renderHook(() =>
+      usePolledEndpoint(fetcher, { intervalMs: 30000 })
+    );
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual({ hello: "world" });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-polls every interval", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ count: 1 });
+    renderHook(() => usePolledEndpoint(fetcher, { intervalMs: 30000 }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/src/hooks/usePolledEndpoint.ts
+++ b/frontend/src/hooks/usePolledEndpoint.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from "react";
+
+interface Options {
+  intervalMs: number;
+  enabled?: boolean;
+}
+
+interface State<T> {
+  data: T | null;
+  error: Error | null;
+  isLoading: boolean;
+  isStale: boolean;
+}
+
+export function usePolledEndpoint<T>(
+  fetcher: () => Promise<T>,
+  { intervalMs, enabled = true }: Options
+): State<T> & { refetch: () => Promise<void> } {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isStale, setIsStale] = useState(false);
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const doFetch = async () => {
+    if (data !== null) setIsStale(true);
+    try {
+      const result = await fetcherRef.current();
+      setData(result);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      setIsLoading(false);
+      setIsStale(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!enabled) return;
+    doFetch();
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        doFetch();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    const intervalId = setInterval(() => {
+      if (document.visibilityState === "visible") {
+        doFetch();
+      }
+    }, intervalMs);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, intervalMs]);
+
+  return { data, error, isLoading, isStale, refetch: doFetch };
+}

--- a/frontend/src/pages/NetworkIntelligenceDashboard.test.tsx
+++ b/frontend/src/pages/NetworkIntelligenceDashboard.test.tsx
@@ -61,7 +61,7 @@ describe("NetworkIntelligenceDashboard", () => {
     expect(screen.getByText(/struggling to hire/i)).toBeInTheDocument();
   });
 
-  it("changing the threshold updates the displayed value", async () => {
+  it("changing the threshold triggers an immediate refetch with the new value", async () => {
     const api = (await import("../api/client")).default as unknown as {
       get: ReturnType<typeof vi.fn>;
     };
@@ -70,18 +70,22 @@ describe("NetworkIntelligenceDashboard", () => {
     });
 
     render(<NetworkIntelligenceDashboard />);
-    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+    // Initial mount: the hook's mount fetch + the filter-change effect's mount
+    // run = 2 calls. (The extra mount call is accepted cost of instant filter
+    // responsiveness — see NetworkIntelligenceDashboard.tsx.)
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
 
-    // The initial threshold is 0.65
     expect(screen.getByText("0.65")).toBeInTheDocument();
 
     const slider = screen.getByRole("slider");
     fireEvent.change(slider, { target: { value: "0.8" } });
 
-    // After the change handler runs, the displayed threshold updates to 0.80.
-    // Note: usePolledEndpoint doesn't refetch on fetcher-identity change
-    // (it only reacts to interval + visibility), so the refetch will happen
-    // on the next poll tick — we assert on the observable state change instead.
+    // The displayed threshold updates + an immediate refetch fires with the
+    // new value (the filter-change effect now covers this — see hook comment).
     await waitFor(() => expect(screen.getByText("0.80")).toBeInTheDocument());
+    await waitFor(() => {
+      const urls = api.get.mock.calls.map((c) => c[0] as string);
+      expect(urls.some((u) => u.includes("threshold=0.8"))).toBe(true);
+    });
   });
 });

--- a/frontend/src/pages/NetworkIntelligenceDashboard.test.tsx
+++ b/frontend/src/pages/NetworkIntelligenceDashboard.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import NetworkIntelligenceDashboard from "./NetworkIntelligenceDashboard";
+
+vi.mock("../api/client", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+describe("NetworkIntelligenceDashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders loading then empty state when the list is empty", async () => {
+    const api = (await import("../api/client")).default as unknown as {
+      get: ReturnType<typeof vi.fn>;
+    };
+    api.get.mockResolvedValue({
+      data: { people: [], threshold_used: 0.65, total: 0 },
+    });
+
+    render(<NetworkIntelligenceDashboard />);
+    await waitFor(() =>
+      expect(screen.getByText(/no signals in your network/i)).toBeInTheDocument()
+    );
+  });
+
+  it("renders the list of people when the endpoint returns rows", async () => {
+    const api = (await import("../api/client")).default as unknown as {
+      get: ReturnType<typeof vi.fn>;
+    };
+    api.get.mockResolvedValue({
+      data: {
+        people: [
+          {
+            connection_id: "abc",
+            name: "Jane Doe",
+            title: "VP Engineering",
+            company: "Acme",
+            relationship_degree: 1,
+            mutual_count: null,
+            aggregate_score: 0.82,
+            trend_direction: "up",
+            last_signal_at: new Date().toISOString(),
+            recent_post_snippet: "We've been interviewing for 4 months…",
+            matching_signal_phrase: "struggling to hire",
+            recent_post_url: null,
+          },
+        ],
+        threshold_used: 0.65,
+        total: 1,
+      },
+    });
+
+    render(<NetworkIntelligenceDashboard />);
+    await waitFor(() => expect(screen.getByText("Jane Doe")).toBeInTheDocument());
+    expect(screen.getByText(/VP Engineering/)).toBeInTheDocument();
+    expect(screen.getByText(/82%/)).toBeInTheDocument();
+    expect(screen.getByText(/struggling to hire/i)).toBeInTheDocument();
+  });
+
+  it("changing the threshold updates the displayed value", async () => {
+    const api = (await import("../api/client")).default as unknown as {
+      get: ReturnType<typeof vi.fn>;
+    };
+    api.get.mockResolvedValue({
+      data: { people: [], threshold_used: 0.65, total: 0 },
+    });
+
+    render(<NetworkIntelligenceDashboard />);
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+
+    // The initial threshold is 0.65
+    expect(screen.getByText("0.65")).toBeInTheDocument();
+
+    const slider = screen.getByRole("slider");
+    fireEvent.change(slider, { target: { value: "0.8" } });
+
+    // After the change handler runs, the displayed threshold updates to 0.80.
+    // Note: usePolledEndpoint doesn't refetch on fetcher-identity change
+    // (it only reacts to interval + visibility), so the refetch will happen
+    // on the next poll tick — we assert on the observable state change instead.
+    await waitFor(() => expect(screen.getByText("0.80")).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/NetworkIntelligenceDashboard.tsx
+++ b/frontend/src/pages/NetworkIntelligenceDashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import api from "../api/client";
 import { usePolledEndpoint } from "../hooks/usePolledEndpoint";
 
@@ -41,9 +41,19 @@ export function NetworkIntelligenceDashboard() {
     return data;
   }, [threshold, tiers]);
 
-  const { data, error, isLoading, isStale } = usePolledEndpoint(fetcher, {
+  const { data, error, isLoading, isStale, refetch } = usePolledEndpoint(fetcher, {
     intervalMs: 30000,
   });
+
+  // Refetch immediately when filter state changes. The polling hook fires every
+  // 30s — too slow for interactive filter feedback. This effect adds instant
+  // responsiveness: move the slider or toggle a tier → new fetch fires now, not
+  // 30s later. The duplicate fetch on initial mount (hook's mount fetch + this
+  // effect's mount run) is harmless: <100ms backend response, happens once.
+  useEffect(() => {
+    refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [threshold, tiers]);
 
   const toggleTier = (t: 1 | 2) => {
     const next = new Set(tiers);

--- a/frontend/src/pages/NetworkIntelligenceDashboard.tsx
+++ b/frontend/src/pages/NetworkIntelligenceDashboard.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useState } from "react";
+import api from "../api/client";
+import { usePolledEndpoint } from "../hooks/usePolledEndpoint";
+
+interface DashboardPerson {
+  connection_id: string;
+  name: string;
+  title: string | null;
+  company: string | null;
+  relationship_degree: 1 | 2;
+  mutual_count: number | null;
+  aggregate_score: number;
+  trend_direction: "up" | "flat" | "down";
+  last_signal_at: string;
+  recent_post_snippet: string | null;
+  matching_signal_phrase: string | null;
+  recent_post_url: string | null;
+}
+
+interface DashboardResponse {
+  people: DashboardPerson[];
+  threshold_used: number;
+  total: number;
+}
+
+const TREND_ICON: Record<DashboardPerson["trend_direction"], string> = {
+  up: "↑",
+  flat: "→",
+  down: "↓",
+};
+
+export function NetworkIntelligenceDashboard() {
+  const [threshold, setThreshold] = useState<number>(0.65);
+  const [tiers, setTiers] = useState<Set<1 | 2>>(new Set([1, 2]));
+
+  const fetcher = useCallback(async (): Promise<DashboardResponse> => {
+    const relationship = [...tiers].sort().join(",");
+    const { data } = await api.get<DashboardResponse>(
+      `/workspace/dashboard/people?threshold=${threshold}&relationship=${relationship}`
+    );
+    return data;
+  }, [threshold, tiers]);
+
+  const { data, error, isLoading, isStale } = usePolledEndpoint(fetcher, {
+    intervalMs: 30000,
+  });
+
+  const toggleTier = (t: 1 | 2) => {
+    const next = new Set(tiers);
+    if (next.has(t)) {
+      next.delete(t);
+    } else {
+      next.add(t);
+    }
+    if (next.size === 0) return; // always keep at least one tier selected
+    setTiers(next);
+  };
+
+  const people = data?.people ?? [];
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: "24px 16px" }}>
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24 }}>
+        <h1 style={{ fontSize: 24, margin: 0 }}>Network Intelligence</h1>
+        {isStale && <span style={{ fontSize: 12, color: "#888" }}>Updating…</span>}
+      </header>
+
+      <section style={{ marginBottom: 24, padding: 16, border: "1px solid #eee", borderRadius: 8 }}>
+        <label style={{ display: "block", marginBottom: 8 }}>
+          Threshold: <strong>{threshold.toFixed(2)}</strong>
+          <input
+            type="range"
+            min={0.5}
+            max={0.95}
+            step={0.05}
+            value={threshold}
+            onChange={(e) => setThreshold(parseFloat(e.target.value))}
+            style={{ width: "100%", marginTop: 4 }}
+          />
+        </label>
+        <div style={{ display: "flex", gap: 16, marginTop: 8 }}>
+          <label>
+            <input
+              type="checkbox"
+              checked={tiers.has(1)}
+              onChange={() => toggleTier(1)}
+            />{" "}
+            1st-degree
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={tiers.has(2)}
+              onChange={() => toggleTier(2)}
+            />{" "}
+            2nd-degree
+          </label>
+        </div>
+      </section>
+
+      {error && (
+        <div style={{ color: "#b00", padding: 12, background: "#fee", borderRadius: 8, marginBottom: 16 }}>
+          Failed to load dashboard: {error.message}
+        </div>
+      )}
+
+      {isLoading && people.length === 0 && (
+        <div style={{ color: "#888", padding: 24, textAlign: "center" }}>Loading…</div>
+      )}
+
+      {!isLoading && people.length === 0 && (
+        <div style={{ color: "#666", padding: 24, textAlign: "center", border: "1px dashed #ddd", borderRadius: 8 }}>
+          No signals in your network above this threshold yet. Try lowering the threshold, or wait for more posts to flow through.
+        </div>
+      )}
+
+      <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+        {people.map((p) => (
+          <li
+            key={p.connection_id}
+            style={{ border: "1px solid #eee", borderRadius: 8, padding: 16, marginBottom: 12 }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+              <div>
+                <span style={{
+                  display: "inline-block", padding: "2px 8px", borderRadius: 12,
+                  background: p.relationship_degree === 1 ? "#d4f7d4" : "#fff3d4",
+                  fontSize: 12, marginRight: 8,
+                }}>
+                  {p.relationship_degree === 1 ? "🟢 1st" : `🟡 2nd${p.mutual_count ? ` · ${p.mutual_count} mutual` : ""}`}
+                </span>
+                <strong>{p.name}</strong>
+                {p.title && <span style={{ color: "#666" }}> · {p.title}</span>}
+                {p.company && <span style={{ color: "#666" }}> at {p.company}</span>}
+              </div>
+              <div style={{ textAlign: "right" }}>
+                <div style={{ fontSize: 18, fontWeight: 600 }}>
+                  {(p.aggregate_score * 100).toFixed(0)}% {TREND_ICON[p.trend_direction]}
+                </div>
+              </div>
+            </div>
+            {p.recent_post_snippet && (
+              <div style={{ marginTop: 8, color: "#444", fontSize: 14 }}>"{p.recent_post_snippet}"</div>
+            )}
+            {p.matching_signal_phrase && (
+              <div style={{ marginTop: 4, fontSize: 12, color: "#888", fontStyle: "italic" }}>
+                Matched: {p.matching_signal_phrase}
+              </div>
+            )}
+            <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
+              {p.recent_post_url && (
+                <a
+                  href={p.recent_post_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{ fontSize: 12, padding: "4px 8px", border: "1px solid #ddd", borderRadius: 4, textDecoration: "none", color: "#333" }}
+                >
+                  View thread
+                </a>
+              )}
+              <button
+                style={{ fontSize: 12, padding: "4px 8px", border: "1px solid #ddd", borderRadius: 4, background: "#fff", cursor: "pointer" }}
+                onClick={() => alert("Outreach drafting — coming soon")}
+              >
+                Draft outreach
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default NetworkIntelligenceDashboard;


### PR DESCRIPTION
## Summary

Ships the full Phase 2 Dashboard slice end-to-end — Ranked People List MVP per `docs/phase-2/dashboard-decisions.md`. After this merges, **3 of 5 Phase 2 slices are shipped** (Foundation, Wizard, Dashboard). Remaining: Backfill, Discovery.

## What's included

### Backend
- **`incremental_trending.py`** — new Celery-friendly aggregation task. Updates `person_signal_summary` within ~100 ms of each scored post. No-op when no signal matched. Computes `trend_direction` (up/flat/down) from this-week vs last-week counts.
- **Pipeline wire-up** — `pipeline.py` now chains `run_dashboard_aggregation_hook` after scoring. Best-match signal resolved from `ring1_matches[0]` (fallback to `ring2_matches[0].signal_id`).
- **Pydantic schemas** in `app/schemas/dashboard.py` — `DashboardPerson`, `DashboardPeopleResponse`. Strict validation (relationship degree 1/2, trend_direction enum, score bounds).
- **`GET /workspace/dashboard/people`** endpoint — `?threshold=&relationship=&limit=`. Joins `person_signal_summary + connections + posts + signals`. Workspace-scoped. Rate-limited 30/min per IP. Post snippets truncated to 200 chars server-side.
- **E2E integration test** — register → wizard → pipeline → dashboard asserts the full flow works.

### Frontend
- **`usePolledEndpoint` hook** — reusable 30s polling hook with tab-visibility pause + `refetch()` escape hatch.
- **`NetworkIntelligenceDashboard.tsx`** — 5-step UI component: threshold slider, 1st/2nd-degree toggles, ranked list with relationship badges + score + trend arrow + post snippet + quick actions.
- **Filter-change refetch fix** — surfaced during Task 8 test writing: filter changes weren't triggering immediate refetch (30s wait). Fixed inline with `useEffect([threshold, tiers], refetch)`.
- **3 Vitest smoke tests** — empty state, rows render correctly, filter change triggers refetch with new URL param.
- **Route wire-up** — `/dashboard` inside `<RequireAuth>` in `App.tsx`.

### E2E
- **Playwright spec** at `e2e/tests/dashboard-golden-path.spec.ts` — marked `.fixme` pending issue #65 (shared register/login selector audit).

### Docs
- **`TODO.md`** — Phase 2 status: 3 of 5 shipped. Dashboard row marked done with specifics.
- **`CLAUDE.md`** — new "Incremental aggregation pattern" bullet documenting the `incremental_trending.py` chain-at-end convention for future per-post aggregation work.

## Design decisions locked

1. **Scope B** — Ranked People List only. Heatmap (Section A) + Trending Topics (Section C) deferred to follow-up slices.
2. **Polling B** — 30s polling + tab-visibility pause. No WebSocket/SSE plumbing.
3. **Filter C** — threshold slider + 1st/2nd-degree relationship toggles. No URL state in MVP.

See `docs/phase-2/dashboard-decisions.md` for full rationale.

## Test plan

- [x] `docker compose exec -T api pytest -q` — **96 passed + 3 skipped** (81+3 baseline + 15 new backend tests across 5 new test files)
- [x] `cd frontend && npm run test:run` — **11 passed** (8 baseline + 3 new NetworkIntelligenceDashboard tests)
- [x] `cd frontend && npm run build` — clean tsc + vite build, no TS errors
- [x] `cd e2e && npx playwright test --list` — 5 tests discovered (4 fixme + 1 new fixme)
- [x] All pre-commit hooks clean on every commit

## Commits (12 atomic)

- `e62919b` feat(dashboard): incremental_trending aggregation task
- `8d87d1a` feat(dashboard): chain incremental_trending after scoring
- `775f3e1` feat(schemas): dashboard response shape
- `9771d72` feat(dashboard): GET /workspace/dashboard/people endpoint
- `4cd6bfd` test(dashboard): end-to-end register → wizard → pipeline → dashboard
- `a7780b2` feat(frontend): usePolledEndpoint hook with tab-visibility pause
- `f3937e6` feat(frontend): NetworkIntelligenceDashboard page
- `3ce8883` test(frontend): NetworkIntelligenceDashboard smoke tests
- `d1a812a` fix(dashboard): refetch immediately on filter change
- `cbc5d27` feat(frontend): wire /dashboard route to NetworkIntelligenceDashboard
- `6155d28` test(e2e): dashboard golden-path (fixme — pending #65)
- `b2adfbc` docs: mark Dashboard slice shipped, document incremental_trending pattern

## Subagent-driven development notes

Each task implemented by a fresh `general-purpose` subagent. 3 returned `DONE_WITH_CONCERNS` with legitimate findings:
- **Task 2** — needed to extract a testable `run_dashboard_aggregation_hook` from `pipeline.py`'s scoring path; also cleaned up pre-existing `== True` ruff violations that would have blocked pre-commit.
- **Task 4** — `Connection.mutual_count` exists in DB (migration 002) but is NOT in the ORM model; subagent substituted `None` to unblock. Worth a follow-up to add it to the ORM.
- **Task 6** — Vitest + `vi.useFakeTimers()` conflicts with `waitFor()`; switched to `{ shouldAdvanceTime: true }` so the tests could pass.
- **Task 8** — discovered the filter-change refetch bug; fixed inline in commit `d1a812a` before continuing.

## Follow-ups (not blocking this PR)

- **Add `mutual_count` to `Connection` ORM model** — DB column exists since migration 002; ORM just needs the field declared.
- **Nav link to `/dashboard`** — currently reachable only via Onboarding redirect, not the top nav. Small polish task.
- **E2E de-fixme** — part of issue #65's broader selector audit.
- **Rolling-average aggregation** — MVP uses simple score replacement. Rolling-avg (e.g., exponential decay) is a follow-up polish task.

## What's next after this lands

Phase 2 has 2 remaining slices: **Backfill** (Chrome extension + Apify for Day-One data) and **Discovery** (Ring 3 HDBSCAN + Weekly Digest). Either could go next; Backfill is the more user-facing (solves the empty-dashboard-on-day-one problem).