### PR TITLE
ci: add Tier C+ enhancements (Claude review, Scorecard, image Trivy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       # category "trivy-image" so they don't collide with the filesystem
       # scan run in trivy.yml (category "trivy-fs").
       - name: Trivy image scan (advisory)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         continue-on-error: true
         with:
           image-ref: sonar-backend:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
   docker-backend:
     name: Docker — backend image build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # for SARIF upload from Trivy image scan
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
@@ -133,6 +136,28 @@ jobs:
         with:
           context: backend
           push: false
+          load: true  # load into local docker so Trivy can scan it
           tags: sonar-backend:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      # Trivy image-CVE scan reuses the artifact already in memory from the
+      # build step above. Advisory while the baseline is established —
+      # SARIF results land in Security tab → Code scanning alerts under
+      # category "trivy-image" so they don't collide with the filesystem
+      # scan run in trivy.yml (category "trivy-fs").
+      - name: Trivy image scan (advisory)
+        uses: aquasecurity/trivy-action@0.28.0
+        continue-on-error: true
+        with:
+          image-ref: sonar-backend:ci
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-image.sarif
+      - name: Upload Trivy image-scan SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        continue-on-error: true
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,43 @@
+name: Claude Code
+
+# AI code review via Claude. Mirrors the pattern used in the smaller
+# nischal94 repos (claude-autotune, anewvibecanvas, selflandingpage).
+#
+# Triggered by `@claude` mentions in issues, PR reviews, and PR review
+# comments — never on every PR (would burn API budget).
+#
+# Requires repo secret ANTHROPIC_API_KEY:
+#   gh secret set ANTHROPIC_API_KEY -R nischal94/sonar
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+name: Scorecard supply-chain security
+
+# OpenSSF Scorecard — automated audit of 18+ supply-chain best practices
+# (branch protection, code review, signed releases, dependency updates,
+# pinned dependencies, token permissions, etc).
+#
+# Runs weekly + on push to main + on branch-protection / workflow changes.
+# Results land in Security → Code scanning alerts AND can be displayed
+# as a public badge in README:
+#
+#   [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/nischal94/sonar/badge)](https://securityscorecards.dev/viewer/?uri=github.com/nischal94/sonar)
+#
+# Optional: enable publish_results to contribute to the public Scorecard
+# dataset (already public for OSS repos; the flag controls the API).
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "30 6 * * 1"   # Mondays 06:30 UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # for SARIF upload to Security tab
+      id-token: write          # for keyless results signing (Sigstore)
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: scorecard


### PR DESCRIPTION
## Summary

Three enhancements layered on top of Tier B PR #82:

| Change | What | Mode |
|---|---|---|
| `ci.yml` (modified) | Adds Trivy image-CVE scan to `docker-backend` job (reuses already-built image via `load: true` — no extra build cost) | advisory; SARIF → Security tab category `trivy-image` |
| `claude.yml` (new) | AI code review via @claude mentions — same pattern used in claude-autotune / selflandingpage / anewvibecanvas | requires `ANTHROPIC_API_KEY` secret |
| `scorecard.yml` (new) | OpenSSF Scorecard — weekly audit of 18+ supply-chain best practices; SARIF upload + public badge | weekly cron + on push to main |

## Action required after merge

```bash
gh secret set ANTHROPIC_API_KEY -R nischal94/sonar
```
Without it, the Claude workflow exists but won't execute (silent no-op until the secret is provisioned).

## Scorecard badge for README

After the first Scorecard run lands:
\`\`\`markdown
[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/nischal94/sonar/badge)](https://securityscorecards.dev/viewer/?uri=github.com/nischal94/sonar)
\`\`\`

## Intentionally deferred

| Item | Why deferred |
|---|---|
| `harden-runner` across existing workflows | Invasive — touches 8+ jobs with risk of breaking legitimate egress (apt/npm/pypi). Better as a dedicated audit-mode rollout PR. |
| SHA-pinning third-party actions | Dependabot keeps tag versions current. SHA-pinning is friction > value at solo-dev scale until you've been hit by a marketplace-action compromise. |
| cosign / SLSA provenance / SBOM | These protect downstream consumers of artifacts. Sonar's Docker image isn't published to a registry; revisit when it is. |

## Test plan

- [ ] CI's `docker-backend` job still passes (image build) and emits a Trivy SARIF
- [ ] Trivy SARIF appears in Security → Code scanning under category `trivy-image`
- [ ] Scorecard runs weekly + once on this PR's push to the branch (won't run on PR — only `push: main` + cron)
- [ ] Claude workflow file is valid YAML (actionlint check passes); won't actually fire until secret is set
- [ ] Existing required checks unchanged