### PR TITLE
fix(ci): clean up e2e.yml shellcheck warnings, promote actionlint to blocking

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,14 +21,8 @@ permissions:
 
 jobs:
   actionlint:
-    # Initially advisory: actionlint surfaces pre-existing shellcheck
-    # warnings in e2e.yml on first run (unused loop vars, unquoted
-    # command substitutions). Same baseline pattern as bandit / trivy.
-    # Promote to required (remove continue-on-error) once those are
-    # resolved in a dedicated cleanup PR.
-    name: actionlint (advisory)
+    name: actionlint
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - name: Download actionlint

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 &
           echo $! > /tmp/api.pid
-          for i in {1..30}; do
+          for _ in {1..30}; do
             curl -sf http://localhost:8000/health && break
             sleep 1
           done
@@ -128,7 +128,7 @@ jobs:
         run: |
           npx vite preview --host 0.0.0.0 --port 5173 &
           echo $! > /tmp/frontend.pid
-          for i in {1..20}; do
+          for _ in {1..20}; do
             curl -sf http://localhost:5173 && break
             sleep 1
           done
@@ -169,5 +169,5 @@ jobs:
       - name: Stop backend + frontend
         if: always()
         run: |
-          kill $(cat /tmp/api.pid) 2>/dev/null || true
-          kill $(cat /tmp/frontend.pid) 2>/dev/null || true
+          kill "$(cat /tmp/api.pid)" 2>/dev/null || true
+          kill "$(cat /tmp/frontend.pid)" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Renames unused loop variable `i` → `_` in two health-check loops (SC2034)
- Quotes command substitutions in the cleanup step (SC2046)
- Removes `continue-on-error: true` from `actionlint.yml` — baseline is now clean

## Test plan

- [ ] actionlint check passes (was the only thing failing on PR #82's first run)
- [ ] e2e.yml still functions (no behavioral change — just shellcheck syntactic fixes)
- [ ] After merge: add `actionlint` to required status checks via branch protection