### PR TITLE
ci: add Tier 4 workflows (OSV-Scanner, Lighthouse CI, Dependabot auto-merge) + grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 
+# Grouping converts update bursts into 1-3 grouped PRs/week per ecosystem
+# instead of N separate PRs. Major upgrades stay individual (breaking
+# changes deserve individual review). See
+# nischal94/repo-template/docs/SECURITY-OPERATIONS.md §5 for the rationale.
+
 updates:
   # Backend Python dependencies (pyproject.toml). Dependabot updates the
   # version pins in pyproject.toml; uv.lock is regenerated as part of merging
@@ -16,6 +21,13 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    groups:
+      pip-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      pip-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
 
   # Frontend npm dependencies.
   - package-ecosystem: "npm"
@@ -30,8 +42,36 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
 
-  # GitHub Actions workflow dependencies (e.g., release-drafter/release-drafter@v6).
+  # E2E npm dependencies (Playwright + test deps live separately).
+  - package-ecosystem: "npm"
+    directory: "/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "e2e"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      e2e-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      e2e-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions workflow dependencies.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -42,3 +82,22 @@ updates:
     commit-message:
       prefix: "chore(ci)"
       include: "scope"
+    groups:
+      gh-actions:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  # Backend Dockerfile base-image updates.
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+    groups:
+      docker:
+        patterns: ["*"]

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs that are safe by semver:
+#   * patch updates on any dep
+#   * minor updates on dev-only deps
+#
+# All other Dependabot PRs (prod minors, all majors) require human
+# review. CI must pass before merge — auto-merge respects required
+# status checks.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+      - name: Auto-merge eligible updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
+           steps.meta.outputs.dependency-type == 'direct:development')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,53 @@
+name: Lighthouse CI
+
+# Performance + a11y + SEO + best-practices gate on the frontend build.
+# Runs against the static vite output served via http-server. Advisory
+# initially — promote to blocking after baseline scores are established.
+#
+# Reports are uploaded as a workflow artifact (downloadable from the
+# run page) and summarised in the action output.
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/lighthouse-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    name: Lighthouse CI (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          # Serve dist/ on port 8080 and audit the index. URLs can be
+          # extended once specific routes deserve dedicated audits.
+          urls: |
+            http://localhost:8080/
+          uploadArtifacts: true
+          temporaryPublicStorage: false
+          configPath: ./.lighthouserc.json
+        env:
+          # The action will start its own server when no URL is reachable;
+          # we don't need to pre-spawn one for a static build.
+          LHCI_BUILD_CONTEXT__GIT_REMOTE: ${{ github.repository }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,36 @@
+name: OSV-Scanner
+
+# Google's OSV-Scanner: cross-ecosystem vulnerability scan against the
+# OSV database. Different advisory source from Dependabot/CodeQL/pip-audit
+# — broader ecosystem coverage. Running multiple sources maximises hit
+# rate while keeping false-positive rate manageable.
+#
+# Runs on PRs that touch dependency manifests + weekly catch-all.
+
+on:
+  pull_request:
+    paths:
+      - "**/pyproject.toml"
+      - "**/uv.lock"
+      - "**/requirements*.txt"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/pnpm-lock.yaml"
+      - "**/yarn.lock"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 7 * * 1"   # Mondays 07:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.9.0
+    with:
+      scan-args: |-
+        --recursive
+        --skip-git
+        ./

--- a/frontend/.lighthouserc.json
+++ b/frontend/.lighthouserc.json
@@ -1,0 +1,20 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "preset": "lighthouse:no-pwa",
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.7 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.85 }],
+        "categories:seo": ["warn", { "minScore": 0.85 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Layered Tier 4 hardening on top of the Tier B/C workflows (#82, #83):

| Change | What | Mode |
|---|---|---|
| **osv-scanner.yml** (new) | Cross-ecosystem vuln scan against Google's OSV DB. Different advisory source from Dependabot/CodeQL/pip-audit — partial overlap, fuller coverage | blocking |
| **lighthouse-ci.yml** (new) + .lighthouserc.json | Frontend perf/a11y/SEO/best-practices audit on every frontend PR | advisory; warn-only thresholds |
| **dependabot-automerge.yml** (new) | Auto-merges Dependabot PRs that are safe-by-semver (patch on any dep, minor on dev-only deps); prod-minors and majors still require human review | n/a (responds to dependabot[bot]) |
| **dependabot.yml** (modified) | Added grouping config across all ecosystems + new e2e/docker blocks. Solves the burst problem | n/a (config) |

## Why grouping in dependabot.yml

Without grouping, the Dependabot security-updates burst on selflandingpage (15) + anewvibecanvas (7) would hit sonar similarly. With grouping:
- Security updates → 1 grouped PR/week per ecosystem
- Minor/patch version updates → 1 grouped PR/week per ecosystem  
- Major upgrades stay individual (breaking changes deserve review)

## Auto-merge trust model

`dependabot-automerge.yml` only merges:
- Patch updates on any dep (semver: bug fixes only)
- Minor updates on **dev-only** deps (test/build tools, not prod runtime)

CI must pass before auto-merge fires (respects required status checks). Prod-minor and all-major upgrades still require manual review.

## Operational reference

Full rationale + when-to-tune lives in [`nischal94/repo-template/docs/SECURITY-OPERATIONS.md`](https://github.com/nischal94/repo-template/blob/main/docs/SECURITY-OPERATIONS.md):
- §5 Dependabot operations (grouping, triage runbook)
- §6 Auto-merge for patch updates (trust model)
- §7.4 OSV-Scanner
- §7.7 Lighthouse CI

## Test plan

- [ ] osv-scanner runs on this PR (no manifest changes, expected to pass with no findings)
- [ ] lighthouse-ci runs (frontend/** is touched indirectly — actually no, this PR only touches .github/ + frontend/.lighthouserc.json. Will validate on a real frontend PR.)
- [ ] All existing required checks pass
- [ ] After merge: dependabot-automerge.yml will become active for next Dependabot PR cycle