### PR TITLE
fix(security): run containers as non-root (resolves Trivy DS-0002)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,23 +1,32 @@
 FROM python:3.12-slim
 
-# System deps for psycopg2-binary fallback, cryptography, etc.
+# Create non-root user (UID 1000) early so subsequent dir creation can chown
+# directly to it. Resolves Trivy DS-0002 (containers must specify USER).
+RUN useradd --create-home --shell /bin/bash --uid 1000 sonar
+
+# System deps for psycopg2-binary fallback, cryptography, etc. (still root)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpq-dev \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv (fast Python package manager)
+# Install uv (fast Python package manager) — into /bin (root-owned, world-readable)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Store the venv outside /app so the docker-compose volume mount
-# (./backend:/app) does not clobber it at runtime
+# (./backend:/app) does not clobber it at runtime.
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 
+# Pre-create /app and /opt/venv with sonar ownership BEFORE dropping privileges,
+# so `uv sync` can write to /opt/venv as the sonar user.
+RUN mkdir -p /app /opt/venv && chown -R sonar:sonar /app /opt/venv
+
 WORKDIR /app
+USER sonar
 
 # Copy only project metadata first for better layer caching
-COPY pyproject.toml ./
+COPY --chown=sonar:sonar pyproject.toml ./
 
 # Resolve and install all dependencies (including dev extras for pytest)
 RUN uv sync --all-extras

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:20-alpine
+# node:20-alpine ships with a built-in `node` user (UID 1000); no useradd needed.
+# Resolves Trivy DS-0002 (containers must specify USER).
 WORKDIR /app
-COPY package*.json ./
+COPY --chown=node:node package*.json ./
+USER node
 RUN npm install
-COPY . .
+COPY --chown=node:node . .
 EXPOSE 5173
 CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Context — why this change exists

Trivy DS-0002 has been the most senior unresolved finding from the [security audit](https://github.com/nischal94/sonar/issues/88) — flagged HIGH severity on both \`backend/Dockerfile\` and \`frontend/Dockerfile\` for missing \`USER\` directive (containers run as root by default).

It surfaced first in the Tier B PR (#82) and has been re-surfacing on every Dockerfile-touching Dependabot PR since (most recently #89 python 3.12→3.14, where it caused the GitHub-native Trivy code-scanning gate to fail). Tracked in [#88](https://github.com/nischal94/sonar/issues/88) and previously deferred with the framing "needs Dockerfile testing." This PR is that testing.

Before first-customer launch this matters: a container compromise that lets an attacker execute commands inside the running process can escalate to full container takeover when the process runs as root. With a non-root \`USER\`, the same compromise is bounded by Linux DAC.

## What changed

### \`backend/Dockerfile\` (12 lines added, 4 modified)

| Change | Why |
|---|---|
| \`useradd --uid 1000 sonar\` early in build | Creates non-root user with stable UID for any volume-mount UID matching downstream |
| \`mkdir -p /app /opt/venv && chown -R sonar:sonar /app /opt/venv\` BEFORE \`USER sonar\` | \`uv sync\` writes to \`/opt/venv\`; the venv directory must be writable by the user *before* we drop privileges |
| \`USER sonar\` before \`COPY pyproject\` + \`uv sync\` | Dependency install runs unprivileged — limits blast radius even during build |
| \`COPY --chown=sonar:sonar pyproject.toml\` | Avoid root-owned files in sonar's WORKDIR |
| Apt-get + uv binary copy STAY as root | Both legitimately need root: \`apt-get install\` writes to system dirs; \`COPY /uv /bin/\` writes to root-owned \`/bin\` |

### \`frontend/Dockerfile\` (3 lines added, 2 modified)

| Change | Why |
|---|---|
| \`COPY --chown=node:node package*.json ./\` | \`node:20-alpine\` ships with built-in \`node\` user (UID 1000) — no \`useradd\` needed |
| \`USER node\` before \`npm install\` | npm install runs unprivileged; resolves DS-0002 |

## How — implementation choices and trade-offs

**`useradd` vs reusing the python-slim default**: \`python:3.12-slim\` doesn't ship a non-root user. Created \`sonar\` with explicit UID 1000 (not 999, not auto-assigned) so:
- Stable across image rebuilds (auto-assigned UIDs can drift if base image adds users)
- Conventional UID for non-root containers (matches Kubernetes \`runAsNonRoot\` defaults)
- Easy to UID-match in docker-compose volume mounts during dev

**\`USER\` directive placement**: chose to drop privileges as early as possible (right after creating user + setting up dirs) rather than at the very end. This means \`uv sync\` runs as \`sonar\`. Trade-off: longer chain of unprivileged operations is safer (defense in depth) but slightly slower if \`uv\` does anything that benefits from root caching.

**\`/opt/venv\` ownership transfer timing**: had to pre-create AND chown \`/opt/venv\` *before* the \`USER\` switch. If \`/opt/venv\` doesn't exist when sonar tries to \`uv sync\`, sonar can't create it (root-owned parent). The \`mkdir -p && chown\` line is load-bearing.

**Frontend \`node:20-alpine\` simplification**: alpine already provides the \`node\` user. Used it instead of creating a \`sonar\` user for parity — keeping it minimal.

## Risk assessment

**Blast radius**: this repo. Affects:
- Production deploys (the fix's whole point)
- CI's \`Docker — backend image build\` (verifies build still works)
- Local dev via docker-compose (potential UID conflict — see below)

**Reversibility**: trivial — \`git revert\` restores root-running Dockerfiles.

**Likelihood of breakage**:
- **Build-time**: tested mentally for the \`uv sync\` write path. \`/opt/venv\` is sonar-owned; \`uv\` doesn't need root.
- **Run-time (prod)**: unaffected unless the app tries to write outside \`/app\` or \`/opt/venv\`. uvicorn binds to port 8000 (>1024, no privileged port issue). No log-file writes (logs go to stdout). Should be safe.
- **Local dev (docker-compose volume mount)**: macOS host UID 501 + container UID 1000 may produce file-ownership warnings when host edits files. Workaround if needed: add \`user: "${UID:-1000}"\` to the backend service in docker-compose. NOT done in this PR — keeping scope tight.

**Specific edge cases ruled out**:
- pgvector / asyncpg: connect via TCP, no socket-permission issues
- Migrations (alembic): run as sonar inside container; uv's venv is sonar-owned, so alembic CLI works
- pytest: runs against test DB on localhost; no fs permission issues

## Test plan

- [ ] CI's \`Docker — backend image build\` passes (verifies the new Dockerfile builds and Trivy image-CVE step still completes)
- [ ] CI's \`Backend — tests\` passes (runs against the test container — implicitly verifies the venv was correctly installed under \`sonar\`)
- [ ] CI's \`E2E — Playwright (chromium)\` passes (full stack containerized; verifies app runs as non-root end-to-end)
- [ ] **GitHub-native Trivy** code scan check on this PR: DS-0002 alerts should NOT show as "new" — they should be resolved (artifact: 0 net new alerts)
- [ ] **After merge**: the 2 DS-0002 alerts in Security tab → Code scanning move from "open" to "fixed" automatically
- [ ] **After merge**: next Dockerfile-touching Dependabot PR (e.g., a future python image bump) does NOT fail the Trivy gate for DS-0002

## Reviewer focus

1. **\`backend/Dockerfile\` line 22-26** — the chown + USER ordering is load-bearing. Verify \`mkdir + chown\` happens BEFORE \`USER sonar\`, and \`COPY --chown\` is used after the USER switch.
2. **CI's Backend — tests result** — this is the smoke test. If \`uv sync\` writing to \`/opt/venv\` as sonar fails, the backend job won't even start; tests can't run; you'll see early failure in the build step.
3. **No \`docker-compose.yml\` changes in this PR** — deliberately scoped out. If local dev breaks for you with the new Dockerfile, that's a separate compose-side fix (UID matching). Flag it; we'll handle in a follow-up.

## Rollback plan

```bash
gh pr revert <merge-sha> -R nischal94/sonar
```
Restores root-running containers. No state to clean up. The only persistent effect of this PR is the GitHub Security tab moves DS-0002 from "open" → "fixed"; revert moves them back to "open." No data, no migrations.

If only ONE Dockerfile breaks (e.g., backend works but frontend breaks), revert just that file via:
```bash
git checkout main -- frontend/Dockerfile && git commit -m "revert(frontend): restore root user; backend stays non-root"
```

## Post-merge actions

- [ ] Verify Security tab shows DS-0002 alerts as "fixed" (sonar/security/code-scanning)
- [ ] Update [#88](https://github.com/nischal94/sonar/issues/88) — bandit ✅ + DS-0002 ✅; remaining items are ruff, Lighthouse, DS-0026 (HEALTHCHECK)
- [ ] Consider follow-up: \`HEALTHCHECK\` directive (DS-0026, LOW) — small additional Dockerfile hardening
- [ ] **If local dev breaks**: add \`user: "${UID:-1000}"\` to backend + frontend services in \`docker-compose.yml\`; possibly an entrypoint script to fix volume-mount ownership

## References

- Trivy [DS-0002 documentation](https://avd.aquasec.com/misconfig/ds-0002)
- OWASP container security: [Run as non-root user](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers)
- Issue: partially resolves [sonar#88](https://github.com/nischal94/sonar/issues/88)
- Doc: \`nischal94/repo-template/docs/SECURITY-OPERATIONS.md §7\` (Tier 4 hardening — this is the Dockerfile portion)
- Prior context: this PR exists because every Dockerfile-touching Dependabot PR (#82, #83, #89) hit the same DS-0002 gate; resolving it on \`main\` unblocks the gate for future bumps

## Follow-ups intentionally NOT in this PR

- **\`HEALTHCHECK\` directive (Trivy DS-0026, LOW)** — separate Dockerfile change; bundled later if/when desired
- **\`docker-compose.yml\` UID-matching** — only needed if local dev breaks; not preemptively added
- **Frontend Dockerfile prod-vs-dev split** — current frontend Dockerfile runs \`npm run dev\` (it's a dev image); a true production Dockerfile would build static assets and serve via nginx/caddy. Out of scope here
- **Backend Dockerfile multi-stage build** — could split build deps (\`build-essential\`, \`libpq-dev\`) into a builder stage and ship a smaller runtime image. Optimization, not security; defer

---

## Checklist

- [x] PR title follows Conventional Commits (\`fix(security):\`)
- [ ] All CI checks pass (waiting on push)
- [x] No secrets, debug statements, or commented-out code in the diff
- [x] No CHANGELOG entry needed (release-please picks up the conventional commit)
- [x] No new blocking checks introduced
- [x] Follow-ups captured: HEALTHCHECK, docker-compose UID, prod-vs-dev frontend, multi-stage backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container security by configuring both backend and frontend Docker images to run with non-root user privileges instead of root access, reducing potential security risks in containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->