### PR TITLE
fix(wizard): gpt-5.4-mini param rename + list-top-level LLM output tolerance

### DIFF
--- a/backend/app/routers/signals.py
+++ b/backend/app/routers/signals.py
@@ -65,7 +65,17 @@ async def propose_signals(
     )
     try:
         payload = json.loads(_strip_markdown_fence(raw))
-        signals_raw = payload["signals"]
+        # gpt-5.4-mini sometimes returns the top-level array directly
+        # (`[{...}, ...]`) instead of the documented `{"signals": [...]}`
+        # shape — accept either form defensively. Long-term fix is to wire
+        # OpenAI Structured Outputs via response_format=json_schema (see
+        # RESPONSE_JSON_SCHEMA in propose_signals.py), tracked in follow-up.
+        if isinstance(payload, list):
+            signals_raw = payload
+        elif isinstance(payload, dict):
+            signals_raw = payload["signals"]
+        else:
+            raise ValueError(f"unexpected LLM output type: {type(payload).__name__}")
         signals = [ProposedSignal(**s) for s in signals_raw]
     except (json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
         raise HTTPException(status_code=502, detail=f"LLM output parse failed: {exc}")

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -44,11 +44,15 @@ class OpenAILLMProvider:
         system: str | None = None,
         max_tokens: int = 2048,
     ) -> str:
+        # OpenAI renamed `max_tokens` → `max_completion_tokens` for the gpt-5+
+        # model generation (including gpt-5.4-mini). The old parameter name is
+        # hard-rejected. Keep the Python kwarg named max_tokens for caller
+        # stability; translate at the API boundary.
         response = await self._client.chat.completions.create(
             model=model,
             messages=_build_messages(prompt, system),
             temperature=0.3,
-            max_tokens=max_tokens,
+            max_completion_tokens=max_tokens,
         )
         return response.choices[0].message.content
 

--- a/backend/tests/test_propose_signals_shape.py
+++ b/backend/tests/test_propose_signals_shape.py
@@ -46,8 +46,17 @@ async def test_propose_signals_prompt_produces_valid_shape(inputs):
     production acceptance rate, not here. See docs/phase-2/wizard-decisions.md §3b."""
     provider = OpenAILLMProvider()
     user_msg = build_user_message(inputs["what_you_sell"], inputs["icp"])
-    prompt = f"<|system|>\n{SYSTEM_PROMPT}\n<|user|>\n{user_msg}"
-    raw = await provider.complete(prompt, model=OPENAI_MODEL_EXPENSIVE)
+    # Mirror the production call site (app/routers/signals.py::propose_signals):
+    # pass SYSTEM_PROMPT via the system kwarg, NOT concatenated into the user
+    # message. Inlining violates the prompt-injection discipline in CLAUDE.md —
+    # user input must only appear in the user-role message. max_tokens matches
+    # the router so truncation behavior is identical.
+    raw = await provider.complete(
+        user_msg,
+        model=OPENAI_MODEL_EXPENSIVE,
+        system=SYSTEM_PROMPT,
+        max_tokens=4096,
+    )
 
     # Strip markdown fence if present
     s = raw.strip()
@@ -57,8 +66,15 @@ async def test_propose_signals_prompt_produces_valid_shape(inputs):
             s = s[:-3]
     payload = json.loads(s.strip())
 
-    assert "signals" in payload
-    signals = payload["signals"]
+    # Mirror the router's shape tolerance: accept either a top-level list
+    # `[{...}]` or the documented `{"signals": [...]}` dict form. gpt-5.4-mini
+    # emits both shapes depending on the call. Long-term fix is Structured
+    # Outputs via response_format=json_schema; tracked in followup.
+    if isinstance(payload, list):
+        signals = payload
+    else:
+        assert "signals" in payload
+        signals = payload["signals"]
     assert 8 <= len(signals) <= 10, f"expected 8-10 signals, got {len(signals)}"
 
     phrases_seen = set()

--- a/backend/tests/test_propose_signals_shape.py
+++ b/backend/tests/test_propose_signals_shape.py
@@ -66,15 +66,20 @@ async def test_propose_signals_prompt_produces_valid_shape(inputs):
             s = s[:-3]
     payload = json.loads(s.strip())
 
-    # Mirror the router's shape tolerance: accept either a top-level list
-    # `[{...}]` or the documented `{"signals": [...]}` dict form. gpt-5.4-mini
-    # emits both shapes depending on the call. Long-term fix is Structured
-    # Outputs via response_format=json_schema; tracked in followup.
+    # Mirror the router's shape tolerance EXACTLY: three-way branch that
+    # accepts a top-level list `[{...}]`, the documented `{"signals": [...]}`
+    # dict form, OR fails loudly on a scalar/None. gpt-5.4-mini emits both
+    # valid shapes depending on the call. Keeping this in lockstep with
+    # app/routers/signals.py::propose_signals means a future scalar-output
+    # regression fails with a clear message here, same as in production.
+    # Long-term fix is Structured Outputs via response_format=json_schema;
+    # tracked in followup.
     if isinstance(payload, list):
         signals = payload
-    else:
-        assert "signals" in payload
+    elif isinstance(payload, dict):
         signals = payload["signals"]
+    else:
+        raise AssertionError(f"unexpected LLM output type: {type(payload).__name__}")
     assert 8 <= len(signals) <= 10, f"expected 8-10 signals, got {len(signals)}"
 
     phrases_seen = set()

--- a/backend/tests/test_propose_signals_shape_tolerance.py
+++ b/backend/tests/test_propose_signals_shape_tolerance.py
@@ -1,0 +1,131 @@
+"""CI-safe unit tests for propose_signals LLM-output shape tolerance.
+
+Complements tests/test_propose_signals_shape.py, which hits the real OpenAI
+API and is skipped on forks without the secret. This file injects a FakeLLM
+via FastAPI dependency_overrides so the list/dict/scalar branches in
+app.routers.signals.propose_signals run in every CI build.
+
+See the Wizard-dogfood PR (fix/wizard-llm-shape-and-params) for the bug that
+motivated the shape tolerance: gpt-5.4-mini occasionally returns a top-level
+list `[{...}]` instead of the documented `{"signals": [...]}` dict.
+"""
+
+from __future__ import annotations
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from app.main import app
+from app.services.llm import get_llm_client
+from app.services.embedding import get_embedding_provider
+
+
+# 9 signals fits the 8-10 schema bound in ProposeSignalsResponse.
+_NINE_SIGNALS = [
+    {
+        "phrase": f"signal {i}",
+        "example_post": f"example post body {i} with enough length to satisfy validation",
+        "intent_strength": 0.5 + i * 0.01,
+    }
+    for i in range(9)
+]
+
+
+@dataclass
+class _ScriptedLLM:
+    """Returns a caller-supplied string verbatim from complete().
+
+    Naming: NOT FakeLLM — the other Wizard tests already bind `FakeLLM` to a
+    dict-shape fixture and this file is about the DIFFERENT shapes. Distinct
+    name keeps future grep-based test discovery unambiguous.
+    """
+
+    payload: Any
+
+    async def complete(self, prompt: str, model: str, **kwargs) -> str:
+        if isinstance(self.payload, str):
+            return self.payload
+        return json.dumps(self.payload)
+
+
+class _FakeEmbed:
+    async def embed(self, text: str) -> list[float]:
+        return [0.1] * 1536
+
+
+async def _auth_headers(client) -> dict:
+    """Register a throwaway workspace and return an Authorization header."""
+    email = "shape-tolerance@test.com"
+    await client.post(
+        "/workspace/register",
+        json={
+            "workspace_name": "Shape Tolerance Test",
+            "email": email,
+            "password": "pass123",
+        },
+    )
+    tok = (
+        await client.post(
+            "/auth/token", data={"username": email, "password": "pass123"}
+        )
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {tok}"}
+
+
+@pytest.mark.asyncio
+async def test_propose_accepts_dict_with_signals_key(client, db_session):
+    """Documented shape: {"signals": [...]}. Canonical happy path."""
+    app.dependency_overrides[get_llm_client] = lambda: _ScriptedLLM(
+        {"signals": _NINE_SIGNALS}
+    )
+    app.dependency_overrides[get_embedding_provider] = lambda: _FakeEmbed()
+    try:
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspace/signals/propose",
+            json={"what_you_sell": "fractional CTO", "icp": "Series A founders"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()["signals"]) == 9
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_propose_accepts_top_level_list(client, db_session):
+    """Bug #2 from dogfood: gpt-5.4-mini emits `[{...}]` instead of
+    `{"signals": [...]}`. The router must tolerate both identically."""
+    app.dependency_overrides[get_llm_client] = lambda: _ScriptedLLM(_NINE_SIGNALS)
+    app.dependency_overrides[get_embedding_provider] = lambda: _FakeEmbed()
+    try:
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspace/signals/propose",
+            json={"what_you_sell": "fractional CTO", "icp": "Series A founders"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()["signals"]) == 9
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_propose_rejects_scalar_payload(client, db_session):
+    """Bare scalars (bool, int, string after json.loads) must 502 cleanly,
+    not TypeError. Covers the `else: raise ValueError` branch."""
+    app.dependency_overrides[get_llm_client] = lambda: _ScriptedLLM(42)
+    app.dependency_overrides[get_embedding_provider] = lambda: _FakeEmbed()
+    try:
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspace/signals/propose",
+            json={"what_you_sell": "fractional CTO", "icp": "Series A founders"},
+            headers=headers,
+        )
+        assert resp.status_code == 502
+        assert "unexpected LLM output type" in resp.json()["detail"]
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

Two bugs in the Signal Configuration Wizard caught during the first real end-to-end dogfood of the product, plus one prompt-injection discipline fix in the existing test.

- **`max_tokens` → `max_completion_tokens`.** OpenAI's `gpt-5.4-mini` hard-rejects the old parameter name with `"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."` `OpenAILLMProvider.complete` now translates at the API boundary: callers keep passing `max_tokens` for stability, the API sees `max_completion_tokens`. Groq is unaffected.
- **Top-level JSON array tolerance.** `gpt-5.4-mini` sometimes returns `[{...}, ...]` instead of the documented `{"signals": [...]}`, causing `/workspace/signals/propose` to 502 with `"list indices must be integers or slices, not str"`. `propose_signals` now accepts either shape defensively. Long-term fix is OpenAI Structured Outputs via `response_format=json_schema` (tracked as a followup).
- **Prompt-injection discipline in the test.** `test_propose_signals_shape` used to inline `SYSTEM_PROMPT` into the user message via `f"<|system|>...<|user|>..."` — violates the "user input belongs ONLY in the user-role message" rule in `CLAUDE.md`. Now uses the `system=` kwarg like the production call site.

Added a CI-safe unit-test file (`test_propose_signals_shape_tolerance.py`) that exercises all three shape branches (dict / list / scalar) via `app.dependency_overrides` and a scripted LLM, so regression coverage no longer requires a real OpenAI key.

## Test plan

- [x] `docker compose exec -T api pytest -q` — 125 passed, 0 failing
- [x] Live dogfood session verified both bugs reproduced on `main` and are resolved after these changes
- [x] Independent review via `superpowers:code-reviewer` — approved, feedback addressed in second commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced robustness of the signal proposal endpoint by supporting multiple valid output formats from the language model backend with clearer error messages for invalid inputs

* **Tests**
  * Added comprehensive test coverage to validate the signal proposal API's tolerance for different output formats and proper handling of edge cases and invalid inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->