### PR TITLE
feat(backfill): wire day_one_backfill Celery task + end-to-end dogfood fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ build/
 htmlcov/
 .coverage
 
+# Celery beat file-based scheduler checkpoint (per-minute runtime state,
+# should never be committed).
+celerybeat-schedule
+
 # Node / Extension
 node_modules/
 dist/

--- a/backend/app/jobs/day_one_backfill_task.py
+++ b/backend/app/jobs/day_one_backfill_task.py
@@ -1,0 +1,66 @@
+"""Celery task wrapper around run_day_one_backfill.
+
+The pure async worker lives in app.workers.day_one_backfill. This module
+adapts it for Celery: a sync entry point that stands up its own engine +
+async session (Celery can't await), resolves the real Apify service, and
+runs the coroutine.
+
+Pattern matches app/jobs/public_poller.py — kept in app/jobs/ (not
+app/workers/) so Celery-scheduled wrappers and the pure pipeline code
+stay separated.
+"""
+
+from __future__ import annotations
+import asyncio
+import logging
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.config import get_settings
+from app.services.apify import get_apify_service
+from app.workers.celery_app import celery_app
+from app.workers.day_one_backfill import run_day_one_backfill
+
+# Eager imports so SQLAlchemy's configure_mappers() can resolve string-name
+# relationships (e.g. Workspace.users → "User") at first query. The Celery
+# worker process hasn't loaded these via any other import path — without
+# them the first query raises "expression 'User' failed to locate a name".
+# Match the full model set registered against Base to cover any relationship.
+from app.models import (  # noqa: F401
+    alert,
+    company_signal_summary,
+    connection,
+    feedback,
+    outreach,
+    person_signal_summary,
+    post,
+    signal,
+    signal_proposal_event,
+    trend,
+    user,
+    workspace,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="app.jobs.day_one_backfill_task.run_day_one_backfill_task")
+def run_day_one_backfill_task(workspace_id: str) -> int:
+    """Sync Celery entry point. Returns profile count for result backend."""
+    return asyncio.run(_run(workspace_id))
+
+
+async def _run(workspace_id: str) -> int:
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as db:
+            return await run_day_one_backfill(
+                db,
+                workspace_id=UUID(workspace_id),
+                apify=get_apify_service(),
+            )
+    finally:
+        await engine.dispose()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,7 +33,20 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],  # Vite dev server
+    allow_origins=[
+        "http://localhost:5173",  # Vite dev server
+        # Content scripts on linkedin.com fetch with Origin: https://www.linkedin.com
+        # (MV3 content scripts share the page's network origin, not the extension's).
+        # Safe because /extension/* endpoints still require the Bearer token held
+        # only in chrome.storage.local, inaccessible from page-world scripts. Prod
+        # should route these calls through the service worker (chrome-extension
+        # origin already allowed via allow_origin_regex below) — tracked as a
+        # hardening follow-up.
+        "https://www.linkedin.com",
+    ],
+    # Chrome extensions send requests from chrome-extension://<id> — the id is
+    # per-install and unpredictable, so we match the scheme with a regex.
+    allow_origin_regex=r"^chrome-extension://[a-z0-9]+$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,19 +35,33 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:5173",  # Vite dev server
-        # Content scripts on linkedin.com fetch with Origin: https://www.linkedin.com
-        # (MV3 content scripts share the page's network origin, not the extension's).
-        # Safe because /extension/* endpoints still require the Bearer token held
-        # only in chrome.storage.local, inaccessible from page-world scripts. Prod
-        # should route these calls through the service worker (chrome-extension
-        # origin already allowed via allow_origin_regex below) — tracked as a
-        # hardening follow-up.
+        # MV3 content scripts running on linkedin.com fetch with
+        # Origin: https://www.linkedin.com because they share the host page's
+        # network origin, NOT chrome-extension://<id>. Without this, the
+        # day-one scan scraper in extension/content/capture-connections.js
+        # can't POST to /extension/connections/bulk.
+        #
+        # Trade-off this accepts, documented honestly:
+        #   - /extension/* and /workspace/* remain gated by the Bearer token in
+        #     chrome.storage.local, which page-world scripts CANNOT read. Safe.
+        #   - /auth/token (unauthenticated) is now invokable + response-readable
+        #     by any script running on linkedin.com. It's rate-limited at
+        #     5/minute per IP, so brute force is bounded, but a targeted
+        #     phishing script that already has a valid credential could
+        #     harvest a JWT via this path. Acceptable during dogfood; the
+        #     proper fix is routing extension fetches through the service
+        #     worker (which runs under chrome-extension://<id> and hits the
+        #     allow_origin_regex below) so linkedin.com can be removed here.
         "https://www.linkedin.com",
     ],
     # Chrome extensions send requests from chrome-extension://<id> — the id is
-    # per-install and unpredictable, so we match the scheme with a regex.
+    # per-install and unpredictable, so match the scheme with a regex.
     allow_origin_regex=r"^chrome-extension://[a-z0-9]+$",
-    allow_credentials=True,
+    # allow_credentials stays off: we use Authorization: Bearer exclusively
+    # (no cookie sessions on any origin — verified in frontend/src/api/client.ts
+    # and extension/utils/api-client.js). Leaving credentials off prevents any
+    # future accidental cookie-based CSRF path from inheriting this CORS list.
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/app/routers/backfill.py
+++ b/backend/app/routers/backfill.py
@@ -106,17 +106,18 @@ async def backfill_trigger(
         )
 
     # Mark started now to prevent race with a second trigger before the
-    # Celery task picks up.
+    # Celery task picks up. run_day_one_backfill keys idempotency on
+    # backfill_completed_at (not backfill_used), so the worker will still
+    # run this job even though backfill_used is already True here.
     now = datetime.now(timezone.utc)
     ws.backfill_used = True
     ws.backfill_started_at = now
     await db.commit()
 
-    # In prod: enqueue Celery task. For MVP test visibility we return a
-    # synthesized task_id — the actual Celery dispatch is wired in later
-    # tasks once end-to-end infra is in place.
-    task_id = f"backfill-{current_user.workspace_id}-{int(now.timestamp())}"
-    return BackfillTriggerResponse(task_id=task_id, backfill_started_at=now)
+    from app.jobs.day_one_backfill_task import run_day_one_backfill_task
+
+    async_result = run_day_one_backfill_task.delay(str(current_user.workspace_id))
+    return BackfillTriggerResponse(task_id=async_result.id, backfill_started_at=now)
 
 
 @router.get("/workspace/backfill/status", response_model=BackfillStatusResponse)

--- a/backend/app/services/apify.py
+++ b/backend/app/services/apify.py
@@ -27,6 +27,37 @@ from app.config import get_settings
 MAX_POSTS_PER_PROFILE = 3
 
 
+def canonicalize_profile_url(url: str | None) -> str | None:
+    """Canonical form used as the join key between the extension-captured
+    Connection.profile_url and posts returned by Apify.
+
+    Normalizes three axes:
+    - scheme + netloc lowercased (e.g. https://LinkedIn.com → https://linkedin.com).
+      urllib.parse does NOT do this automatically; JS's `new URL(...).origin`
+      does. Without this symmetry the join silently drops posts when Apify
+      returns a redirect-normalized host with different case.
+    - trailing slash stripped from the path.
+    - query, params, fragment dropped (Apify returns `?miniProfileUrn=urn%3A...`
+      tracking params; the extension stores clean `/in/<slug>`).
+
+    Returns None for falsy input so callers can pass Apify fields straight
+    through without a second None check.
+    """
+    if not url:
+        return None
+    parsed = urlparse(url)
+    return urlunparse(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path.rstrip("/"),
+            "",
+            "",
+            "",
+        )
+    )
+
+
 class ApifyProfilePost(BaseModel):
     """Normalized representation of one post returned by Apify.
 
@@ -112,19 +143,7 @@ class RealApifyService:
         try:
             author = item.get("author") or {}
             raw_profile_url = author.get("linkedinUrl") or author.get("profileUrl")
-            # Apify returns profile URLs with tracking query params
-            # (e.g. ?miniProfileUrn=urn%3Ali%3Afsd_profile%3A...), but the
-            # extension scrapes and stores the canonical form
-            # https://www.linkedin.com/in/<slug> (no query, no trailing
-            # slash). Normalize here so the worker's conn_by_url.get()
-            # lookup in run_day_one_backfill can match them.
-            profile_url = None
-            if raw_profile_url:
-                parsed = urlparse(raw_profile_url)
-                stripped_path = parsed.path.rstrip("/")
-                profile_url = urlunparse(
-                    (parsed.scheme, parsed.netloc, stripped_path, "", "", "")
-                )
+            profile_url = canonicalize_profile_url(raw_profile_url)
             post_id = item.get("id")
 
             # postedAt may be a dict ({timestamp, date, relative}) OR a bare

--- a/backend/app/services/apify.py
+++ b/backend/app/services/apify.py
@@ -11,7 +11,8 @@ profile-posts (no cookies, $1.50/1k posts, clean postedLimitDate filter).
 
 from __future__ import annotations
 from datetime import datetime, timedelta, timezone
-from typing import Protocol
+from typing import Protocol, runtime_checkable
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 from pydantic import BaseModel
@@ -43,7 +44,12 @@ class ApifyProfilePost(BaseModel):
     share_count: int = 0
 
 
+@runtime_checkable
 class ApifyService(Protocol):
+    """@runtime_checkable so tests can isinstance-check RealApifyService against
+    the Protocol when a real APIFY_API_TOKEN is configured. Protocol conformance
+    is structural — the decorator just enables the isinstance() check."""
+
     async def scrape_profile_posts(
         self, profile_urls: list[str], days: int
     ) -> list[ApifyProfilePost]: ...
@@ -105,7 +111,20 @@ class RealApifyService:
         """
         try:
             author = item.get("author") or {}
-            profile_url = author.get("linkedinUrl") or author.get("profileUrl")
+            raw_profile_url = author.get("linkedinUrl") or author.get("profileUrl")
+            # Apify returns profile URLs with tracking query params
+            # (e.g. ?miniProfileUrn=urn%3Ali%3Afsd_profile%3A...), but the
+            # extension scrapes and stores the canonical form
+            # https://www.linkedin.com/in/<slug> (no query, no trailing
+            # slash). Normalize here so the worker's conn_by_url.get()
+            # lookup in run_day_one_backfill can match them.
+            profile_url = None
+            if raw_profile_url:
+                parsed = urlparse(raw_profile_url)
+                stripped_path = parsed.path.rstrip("/")
+                profile_url = urlunparse(
+                    (parsed.scheme, parsed.netloc, stripped_path, "", "", "")
+                )
             post_id = item.get("id")
 
             # postedAt may be a dict ({timestamp, date, relative}) OR a bare

--- a/backend/app/workers/celery_app.py
+++ b/backend/app/workers/celery_app.py
@@ -13,7 +13,8 @@ celery_app = Celery(
         "app.workers.pipeline",
         "app.jobs.public_poller",
         "app.jobs.digest_sender",
-    ]
+        "app.jobs.day_one_backfill_task",
+    ],
 )
 
 celery_app.conf.update(
@@ -31,5 +32,5 @@ celery_app.conf.update(
             "task": "app.jobs.digest_sender.send_digests",
             "schedule": 3600.0,  # every hour
         },
-    }
+    },
 )

--- a/backend/tests/test_apify_url_canonicalization.py
+++ b/backend/tests/test_apify_url_canonicalization.py
@@ -1,0 +1,76 @@
+"""Unit tests for canonicalize_profile_url.
+
+This helper is the join key between connections captured by the extension
+(stored in Connection.profile_url) and posts returned by Apify (mapped into
+ApifyProfilePost.profile_url). If the two sides of the join disagree on
+canonical form — case, trailing slash, query params — the worker's
+conn_by_url.get(post.profile_url) silently misses and no posts land against
+that connection.
+
+Cover every normalization axis: scheme/netloc lowercasing, trailing-slash
+stripping, query/params/fragment dropping, and falsy-input pass-through.
+"""
+
+from __future__ import annotations
+import pytest
+
+from app.services.apify import canonicalize_profile_url
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Canonical form round-trips to itself.
+        (
+            "https://www.linkedin.com/in/alice",
+            "https://www.linkedin.com/in/alice",
+        ),
+        # Trailing slash stripped.
+        (
+            "https://www.linkedin.com/in/alice/",
+            "https://www.linkedin.com/in/alice",
+        ),
+        # Tracking query param dropped (Apify's actual output shape).
+        (
+            "https://www.linkedin.com/in/alice?miniProfileUrn=urn%3Ali%3Afsd_profile%3AAB123",
+            "https://www.linkedin.com/in/alice",
+        ),
+        # Fragment dropped.
+        (
+            "https://www.linkedin.com/in/alice#section",
+            "https://www.linkedin.com/in/alice",
+        ),
+        # Uppercase host lowercased — this is the latent bug the reviewer
+        # caught. JS's u.origin lowercases on the extension side; without
+        # lowercasing here, the join would silently miss.
+        (
+            "https://www.LinkedIn.com/in/alice",
+            "https://www.linkedin.com/in/alice",
+        ),
+        # Uppercase scheme lowercased (same reason).
+        (
+            "HTTPS://www.linkedin.com/in/alice",
+            "https://www.linkedin.com/in/alice",
+        ),
+        # Path case preserved — LinkedIn slugs are usually lowercased, but
+        # we don't touch the path beyond trailing-slash stripping.
+        (
+            "https://www.linkedin.com/in/AliceSlug",
+            "https://www.linkedin.com/in/AliceSlug",
+        ),
+        # Multi-axis combination stress test.
+        (
+            "HTTPS://WWW.LINKEDIN.COM/in/alice/?miniProfileUrn=urn%3Ali%3A123#about",
+            "https://www.linkedin.com/in/alice",
+        ),
+    ],
+)
+def test_canonicalize_profile_url_normalizes_all_axes(raw, expected):
+    assert canonicalize_profile_url(raw) == expected
+
+
+@pytest.mark.parametrize("falsy", [None, ""])
+def test_canonicalize_profile_url_returns_none_for_falsy(falsy):
+    """_map_row passes Apify's linkedinUrl straight through, which may be
+    missing. Returning None lets callers skip the row cleanly."""
+    assert canonicalize_profile_url(falsy) is None

--- a/extension/content/capture-connections.js
+++ b/extension/content/capture-connections.js
@@ -12,14 +12,14 @@
   }
 
   function extractConnectionsFromDOM() {
-    // LinkedIn's connections page uses mn-connection-card containers.
-    // Selectors here are brittle by definition — when LinkedIn changes DOM,
-    // this script's telemetry will flag the mismatch.
-    const rows = document.querySelectorAll(".mn-connection-card, [data-chameleon-result-urn]");
-    const out = [];
-    for (const row of rows) {
-      const link = row.querySelector('a[href*="/in/"]');
-      if (!link) continue;
+    // LinkedIn's connections page keeps rebuilding its class names (tested
+    // 2026-04-20: old .mn-connection-card and [data-chameleon-result-urn]
+    // both gone). Instead of chasing class changes, anchor on the stable
+    // fact that every connection has an /in/<slug> profile link, then
+    // dedupe and walk up for headline text.
+    const links = document.querySelectorAll('a[href*="/in/"]');
+    const byId = new Map();
+    for (const link of links) {
       let profile_url;
       try {
         const u = new URL(link.href);
@@ -28,21 +28,60 @@
         continue;
       }
       const linkedin_id = profile_url.split("/in/")[1];
-      if (!linkedin_id) continue;
-      const nameEl = row.querySelector(".mn-connection-card__name, [data-test-app-aware-link] span");
-      const name = nameEl?.textContent?.trim() || "";
-      if (!name) continue;
-      const headlineEl = row.querySelector(".mn-connection-card__occupation");
-      const headline = headlineEl?.textContent?.trim() || null;
-      out.push({
-        linkedin_id,
-        name,
-        headline,
+      if (!linkedin_id || linkedin_id.includes("/")) continue;
+      const text = (link.textContent || "").trim().replace(/\s+/g, " ");
+      const existing = byId.get(linkedin_id);
+      // Per connection LinkedIn renders 2-3 overlapping links (photo wrapper
+      // with empty text + name link with the name). Skip the empty-text
+      // one if we already captured the name, but don't drop the entry.
+      if (existing && existing.name && !text) continue;
+      const name = text || (existing && existing.name) || "";
+      if (!name || name.length < 2) continue;
+
+      // Walk up to 5 ancestors, collecting the first plausible headline
+      // from adjacent <span>/<p> text. Skip UI labels and connection-date
+      // footers.
+      let headline = null;
+      let ancestor = link.parentElement;
+      const skip = /^(Message|Follow|Remove Connection|More|Connected on|Pending)/;
+      for (let i = 0; i < 5 && ancestor && !headline; i++) {
+        const candidates = ancestor.querySelectorAll("span, p");
+        for (const c of candidates) {
+          const t = (c.textContent || "").trim().replace(/\s+/g, " ");
+          if (
+            t &&
+            t !== name &&
+            t.length >= 5 &&
+            t.length <= 200 &&
+            !skip.test(t)
+          ) {
+            headline = t;
+            break;
+          }
+        }
+        ancestor = ancestor.parentElement;
+      }
+
+      // Clamp to backend Pydantic limits (backend/app/schemas/backfill.py):
+      // name max 200, headline max 500, profile_url max 500. LinkedIn's
+      // textContent concatenates the name <span> with the headline <span>
+      // into one string (e.g. "Debayan RoyProduct Marketing | Welingkar
+      // | PGDM'24 | IOCL"), and some users' combined text exceeds 200.
+      // Truncate rather than drop the row — linkedin_id + profile_url
+      // remain clean and are what the backend dedupes/joins on.
+      const clampedName = name.slice(0, 200);
+      const clampedHeadline = headline ? headline.slice(0, 500) : null;
+      const clampedUrl = profile_url.slice(0, 500);
+
+      byId.set(linkedin_id, {
+        linkedin_id: linkedin_id.slice(0, 200),
+        name: clampedName,
+        headline: clampedHeadline,
         company: null,
-        profile_url,
+        profile_url: clampedUrl,
       });
     }
-    return out;
+    return Array.from(byId.values());
   }
 
   async function scrollAndCollect(maxScrolls = 30) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -24,8 +24,7 @@
     }
   ],
   "action": {
-    "default_popup": "popup/popup.html",
-    "default_icon": {"16": "icons/icon16.png", "48": "icons/icon48.png"}
+    "default_popup": "popup/popup.html"
   },
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"


### PR DESCRIPTION
## Summary

Closes the gap where the Phase 2 Backfill trigger endpoint (shipped in PR #73) was specced but never actually wired to Celery — it flipped `Workspace.backfill_used=True`, returned a synthesized task_id, and never enqueued anything. Plus fixes the adjacent bugs that blocked the extension → backend → Celery → Apify → posts pipeline during tonight's first real end-to-end dogfood.

**Backfill wiring**
- New `app/jobs/day_one_backfill_task.py` — Celery task wrapping the existing `run_day_one_backfill`. Mirrors `app/jobs/public_poller.py` (sync entry → `asyncio.run` → fresh engine+session → dispose). Eager-imports all ORM models so `configure_mappers()` resolves string-name relationships like `Workspace.users → "User"` inside the worker process.
- `backfill.py` trigger endpoint now actually dispatches via `.delay(str(workspace_id))`. Import is local to the function to avoid a circular-import loop (Celery → app → router → Celery).
- `apify.py` extracted a `canonicalize_profile_url` helper — lowercases scheme+netloc, strips query/params/fragment, strips trailing slash. Symmetric with the extension's `u.origin + pathname.replace(/\/$/, "")`. Without this the worker's `conn_by_url.get(post.profile_url)` silently dropped every post when Apify returned URLs with `?miniProfileUrn=...` tracking params.
- `apify.py` `ApifyService` Protocol is now `@runtime_checkable` so `isinstance` checks work when a real `APIFY_API_TOKEN` enables the previously-skipped test.

**CORS**
- `main.py` adds `https://www.linkedin.com` to `allow_origins` so MV3 content scripts (which share the host page's network origin) can fetch `/extension/connections/bulk`. The comment is honest about the trade: `/auth/token` is now invokable + response-readable from linkedin.com scripts, rate-limited at 5/minute but not eliminated. Proper fix is routing through the service worker — tracked as a hardening followup.
- `allow_credentials=False` — nothing in the app uses cookies (all auth is Bearer), so credentials-off prevents future accidental cookie-CSRF inheritance of the CORS list.

**Extension**
- `capture-connections.js` rewritten to anchor on `a[href*="/in/"]` instead of obsolete `.mn-connection-card` / `[data-chameleon-result-urn]` classes that LinkedIn's 2026 redesign removed. Dedup by `linkedin_id` parsed from the URL, walk up to 5 ancestors for a headline candidate, skip UI-label spans.
- `capture-connections.js` clamps `name` (≤200), `headline` (≤500), `profile_url` (≤500) to the backend Pydantic max_lengths. LinkedIn's `textContent` joins span children without a separator, so name+headline concatenation was routinely exceeding 200 chars and 422ing the bulk endpoint.
- `manifest.json` removes the `default_icon` block — the referenced PNGs don't exist and Chrome refused the unpacked-extension load with \"Could not load icon 'icons/icon16.png'\".

**Infra**
- `.gitignore` adds `celerybeat-schedule` — file-based scheduler checkpoint, runtime state that Celery Beat rewrites every tick.

**Test coverage added**
- `tests/test_apify_url_canonicalization.py` — 9 unit tests covering every normalization axis of the new helper, including the case-sensitivity drift the reviewer caught (uppercase host in Apify output would silently miss before this change).

## Test plan

- [x] `docker compose exec -T api pytest -q --ignore=tests/test_propose_signals_shape.py` — 129 passed (real-LLM tests depend on PR #103's llm.py fix)
- [x] Live dogfood: clicked Run Day-One Scan → 49 connections captured → POST landed clean → Celery task dispatched (`task_id: 8c122037-...`) → Apify call succeeded in 20.86s → 37 backfill posts ingested → all 37 processed by pipeline → scored posts visible in dashboard
- [x] Independent review via `superpowers:code-reviewer` — SUGGESTIONS (non-blocking), two Important items addressed in second commit (CORS comment honesty + URL canonicalizer helper with symmetric lowercase normalization)

## Follow-ups (not in this PR)

- `scorer: relationship_score returns 0.5 default instead of 0.9 for degree=1` — discovered during dogfood when all 30 scored backfill posts showed relationship=0.5. Real bug, not blocking the Backfill wiring ship.
- `threshold calibration: build golden eval dataset + ROC analysis` — default `matching_threshold=0.72` is mathematically unreachable for backfilled posts (timing=0 ceiling forces relevance≥0.9). Needs empirical calibration with labeled data, not a magic number.
- `CORS hardening: route extension fetches through service worker` — removes the linkedin.com origin from `allow_origins` entirely so `/auth/token` is no longer response-readable by page-world scripts.
- `apify: move token from URL query param to Authorization header` — current harvestapi integration leaks `?token=apify_api_...` into worker logs on every call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Chrome extension support through updated Cross-Origin Resource Sharing configuration
  * Improved connection data extraction with enhanced deduplication and better profile matching capabilities
  * Enhanced profile URL normalization for consistent data handling and linking across all sources

* **Bug Fixes**
  * Improved connection capture reliability and accuracy from LinkedIn profiles

* **Chores**
  * Updated extension manifest configuration and build settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->