### PR TITLE
feat(frontend): add /login page + sign-in link on onboarding

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 // frontend/src/App.tsx
 import { BrowserRouter, Routes, Route, Navigate, Link } from 'react-router-dom';
 import { Onboarding } from './pages/Onboarding';
+import { Login } from './pages/Login';
 import { AlertFeed } from './pages/AlertFeed';
 import { OpportunityBoard } from './pages/OpportunityBoard';
 import { Settings } from './pages/Settings';
@@ -28,6 +29,7 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Onboarding />} />
+        <Route path="/login" element={<Login />} />
         <Route path="/alerts" element={<RequireAuth><Nav /><AlertFeed /></RequireAuth>} />
         <Route path="/board" element={<RequireAuth><Nav /><OpportunityBoard /></RequireAuth>} />
         <Route path="/settings" element={<RequireAuth><Nav /><Settings /></RequireAuth>} />

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,59 @@
+// frontend/src/pages/Login.tsx
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { authAPI } from '../api/client';
+
+export function Login() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  async function handleLogin(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    const form = e.currentTarget;
+    const email = (form.elements.namedItem('email') as HTMLInputElement).value;
+    const password = (form.elements.namedItem('password') as HTMLInputElement).value;
+    try {
+      const resp = await authAPI.login(email, password);
+      localStorage.setItem('sonar_token', resp.data.access_token);
+      navigate('/dashboard');
+    } catch {
+      setError('Incorrect email or password.');
+    }
+    setLoading(false);
+  }
+
+  return (
+    <div style={{ maxWidth: 480, margin: '80px auto', padding: 24 }}>
+      <h1 style={{ fontSize: 24, marginBottom: 8 }}>⚡ Sign in to Sonar</h1>
+      <p style={{ color: '#666', marginBottom: 32 }}>Welcome back.</p>
+
+      <form onSubmit={handleLogin}>
+        <input name="email" type="email" placeholder="Email" required style={inputStyle} />
+        <input name="password" type="password" placeholder="Password" required style={inputStyle} />
+        {error && <p style={{ color: '#dc2626', fontSize: 13 }}>{error}</p>}
+        <button type="submit" disabled={loading} style={btnStyle}>
+          {loading ? 'Signing in...' : 'Sign in →'}
+        </button>
+      </form>
+
+      <p style={{ color: '#666', fontSize: 14, marginTop: 24, textAlign: 'center' }}>
+        New to Sonar?{' '}
+        <Link to="/" style={{ color: '#0077b5', textDecoration: 'none' }}>
+          Create a workspace
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', padding: '10px 12px', marginBottom: 12, fontSize: 14,
+  border: '1px solid #e5e7eb', borderRadius: 6, boxSizing: 'border-box',
+};
+const btnStyle: React.CSSProperties = {
+  width: '100%', padding: '10px 0', background: '#0077b5', color: 'white',
+  border: 'none', borderRadius: 6, fontSize: 14, fontWeight: 600, cursor: 'pointer',
+};

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1,6 +1,6 @@
 // frontend/src/pages/Onboarding.tsx
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { authAPI, profileAPI } from '../api/client';
 
 export function Onboarding() {
@@ -60,6 +60,12 @@ export function Onboarding() {
           <button type="submit" disabled={loading} style={btnStyle}>
             {loading ? 'Creating...' : 'Create Workspace →'}
           </button>
+          <p style={{ color: '#666', fontSize: 14, marginTop: 16, textAlign: 'center' }}>
+            Already have an account?{' '}
+            <Link to="/login" style={{ color: '#0077b5', textDecoration: 'none' }}>
+              Sign in
+            </Link>
+          </p>
         </form>
       )}
 


### PR DESCRIPTION
## Summary
- Adds a minimal `/login` page so returning users can sign in. Previously, the only route handling auth was `Onboarding`, which registers new users — a cleared `localStorage.sonar_token` locked existing users out entirely.
- Adds a "Sign in" link on the Onboarding form so returning users can find the login page.

## Why now
Discovered during session 8 while trying to verify the end-to-end dogfood loop on the existing dogfood account (`nischalsharma94@gmail.com`). Registration rejected (email taken) and there was no alternative UI path back in.

## Implementation notes
- `Login.tsx` mirrors `Onboarding.tsx` conventions (inline styles, named-element form reads, `authAPI.login`, same token key).
- Generic error copy (`"Incorrect email or password."`) doesn't disclose whether the email exists — matches OWASP guidance.
- No changes to the backend auth flow; uses the existing `POST /auth/token` endpoint.

## Test plan
- [x] `npm run build` passes (tsc + vite)
- [x] Code review by `superpowers:code-reviewer` — approved with nits (non-blocking)
- [x] Manual: log in with existing dogfood account, land on `/dashboard`
- [ ] Manual: wrong password → generic error
- [ ] Manual: "Create a workspace" link on `/login` → `/`
- [ ] Manual: "Sign in" link on `/` → `/login`

## Follow-ups (non-blocking)
- Error-swallowing `catch {}` discards real server errors — will address alongside same pattern in `Onboarding.tsx` in a future PR.
- No frontend tests added; project has no integration test suite for auth flows yet (see `CLAUDE.md` Lessons Learned on frontend dep bumps requiring a human in the browser).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added login page with email and password authentication
  * Login form handles authentication and redirects successful users to the dashboard
  * Displays error messages for failed login attempts
  * Added sign-in link on registration page for existing users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->