### PR TITLE
fix(scoring): relationship_score fallback for degree-based connections (#105)

### DIFF
--- a/backend/alembic/versions/007_connection_relationship_score_nullable.py
+++ b/backend/alembic/versions/007_connection_relationship_score_nullable.py
@@ -1,0 +1,50 @@
+"""connections.relationship_score — make nullable, drop 0.5 default
+
+The previous schema forced every new connection to relationship_score=0.5.
+The scorer treats non-NULL values as 'already measured', so the 0.5 default
+silently overrode the degree-based fallback (1st=0.9, 2nd=0.6, 3rd=0.3).
+Every live post scored with relationship_score=0.5 regardless of degree.
+
+Fix: make the column nullable. Callers that know the value (e.g. the
+backfill endpoint, which knows degree=1) set it explicitly; otherwise
+NULL lets the scorer fall back correctly. See issue #105.
+
+Data backfill (UPDATE ... WHERE relationship_score = 0.5) is intentionally
+NOT in this migration — it would silently overwrite any legitimately-measured
+0.5 values. Operators should run the backfill manually (see issue #105 PR).
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-04-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "007"
+down_revision = "006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "connections",
+        "relationship_score",
+        existing_type=sa.Float(),
+        nullable=True,
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE connections SET relationship_score = 0.5 WHERE relationship_score IS NULL"
+    )
+    op.alter_column(
+        "connections",
+        "relationship_score",
+        existing_type=sa.Float(),
+        nullable=False,
+        server_default="0.5",
+    )

--- a/backend/app/models/connection.py
+++ b/backend/app/models/connection.py
@@ -34,7 +34,7 @@ class Connection(Base):
     seniority = Column(String)
     degree = Column(Integer, nullable=False)
     mutual_count = Column(Integer, nullable=False, default=0, server_default="0")
-    relationship_score = Column(Float, nullable=False, default=0.5)
+    relationship_score = Column(Float, nullable=True)
     has_interacted = Column(Boolean, nullable=False, default=False)
     first_seen_at = Column(TIMESTAMPTZ, nullable=False, server_default="now()")
     last_active_at = Column(TIMESTAMPTZ)

--- a/backend/app/routers/backfill.py
+++ b/backend/app/routers/backfill.py
@@ -7,6 +7,7 @@ from app.database import get_db
 from app.models.connection import Connection
 from app.models.user import User
 from app.models.workspace import Workspace
+from app.services.scorer import DEGREE_BASE_SCORE
 from app.rate_limit import limiter
 from app.routers.auth import get_current_user
 from app.schemas.backfill import (
@@ -73,6 +74,7 @@ async def connections_bulk(
                     company=row.company,
                     profile_url=row.profile_url,
                     degree=1,
+                    relationship_score=DEGREE_BASE_SCORE[1],
                 )
             )
 

--- a/backend/tests/test_scorer.py
+++ b/backend/tests/test_scorer.py
@@ -1,11 +1,14 @@
-import pytest
 from datetime import datetime, timezone, timedelta
-from uuid import uuid4
 from app.services.scorer import compute_combined_score, Priority, ScoringResult
 
 
-def make_connection(degree: int = 1, relationship_score: float | None = None, has_interacted: bool = False):
+def make_connection(
+    degree: int = 1,
+    relationship_score: float | None = None,
+    has_interacted: bool = False,
+):
     from types import SimpleNamespace
+
     return SimpleNamespace(
         degree=degree,
         relationship_score=relationship_score,
@@ -35,6 +38,19 @@ def test_low_priority_for_old_third_degree_weak_post():
     assert result.combined_score < 0.55
 
 
+def test_relationship_score_falls_back_to_degree_base_when_null():
+    # Regression for issue #105: when connection.relationship_score is None,
+    # the scorer must fall back to DEGREE_BASE_SCORE, not silently pass through
+    # a stale default. A 1st-degree connection must score at least 0.9.
+    connection = make_connection(degree=1, relationship_score=None)
+    result = compute_combined_score(
+        relevance_score=0.5,
+        connection=connection,
+        posted_at=datetime.now(timezone.utc),
+    )
+    assert result.relationship_score == 0.9
+
+
 def test_relationship_score_boost_for_interaction():
     connection = make_connection(degree=2, relationship_score=None, has_interacted=True)
     result = compute_combined_score(
@@ -49,11 +65,13 @@ def test_relationship_score_boost_for_interaction():
 def test_timing_score_decays_over_24_hours():
     connection = make_connection(degree=1)
     fresh_result = compute_combined_score(
-        relevance_score=0.80, connection=connection,
+        relevance_score=0.80,
+        connection=connection,
         posted_at=datetime.now(timezone.utc) - timedelta(minutes=5),
     )
     old_result = compute_combined_score(
-        relevance_score=0.80, connection=connection,
+        relevance_score=0.80,
+        connection=connection,
         posted_at=datetime.now(timezone.utc) - timedelta(hours=22),
     )
     assert fresh_result.timing_score > old_result.timing_score


### PR DESCRIPTION
Closes #105.

## Problem

`Connection.relationship_score` was declared `NOT NULL DEFAULT 0.5`. The scorer's `if connection.relationship_score is not None` branch treated 0.5 as "already measured" and never fell back to `DEGREE_BASE_SCORE`. Every 1st-degree connection scored 0.5 instead of the documented 0.9.

**Verified live on the dogfood workspace:** all 49 connections had `relationship_score=0.5`, dragging every post's `combined_score` below the default dashboard threshold (0.65) and below the workspace threshold (0.30).

## Fix

1. `backend/app/models/connection.py` — `relationship_score` is now nullable, no default.
2. `backend/alembic/versions/007_connection_relationship_score_nullable.py` — new migration. `downgrade()` backfills NULLs with 0.5 before restoring `NOT NULL`.
3. `backend/app/routers/backfill.py` — the only current ingest site sets `relationship_score=DEGREE_BASE_SCORE[1]` explicitly (belt-and-suspenders).
4. `backend/tests/test_scorer.py` — regression test: degree=1 with NULL scores exactly 0.9.

## Migration does NOT backfill existing rows

Intentional. An unconditional `UPDATE ... SET relationship_score = NULL WHERE relationship_score = 0.5` would silently overwrite any legitimately-measured 0.5 values. Operators can reset stale rows with:

\`\`\`sql
UPDATE connections SET relationship_score = NULL
WHERE relationship_score = 0.5 AND NOT has_interacted;
\`\`\`

## Test plan

- [x] `alembic upgrade head` applies cleanly
- [x] Full suite: 136 passed
- [x] Regression test pinned to exact 0.9 value
- [x] Code review by `superpowers:code-reviewer` — approve-with-nits (test tightened per nit)

## Follow-ups (filed separately)

- #106 — threshold calibration (unblocked by this fix)
- #110 — Ring 1 matcher produces zero hits (signals are phrases, matcher expects keywords)
- #111 — Dashboard threshold slider ignores workspace `matching_threshold`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relationship scores can now be nullable, with automatic fallback to degree-based scoring when absent.
  * New connections receive an appropriate default score upon creation.

* **Tests**
  * Added regression test for null relationship score fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->