### PR TITLE
eval(calibration): matching model calibration harness + dogfood findings (supersedes #106)

### DIFF
--- a/backend/scripts/calibrate_matching.py
+++ b/backend/scripts/calibrate_matching.py
@@ -1,0 +1,442 @@
+"""Matching-threshold calibration harness for Sonar.
+
+Exports per-post top-signal cosine similarities to a labeling markdown file,
+ingests user-provided binary labels, and computes ROC/PR/F1 curves to
+identify an empirically-justified matching_threshold.
+
+Two-phase workflow:
+
+  Phase 1 — export labeling doc:
+      python scripts/calibrate_matching.py export \
+          --workspace-id <uuid> \
+          --out eval/calibration/<name>.md
+
+  Phase 2 — analyze filled-in labels:
+      python scripts/calibrate_matching.py analyze \
+          --workspace-id <uuid> \
+          --labels eval/calibration/<name>.md
+
+The analyzer reports:
+  * distribution of cosines for labeled-match vs labeled-non-match pairs
+  * precision/recall/F1/F0.5 at every threshold 0.00–1.00 (step 0.01)
+  * recommended threshold at max F1 and max F0.5 (false-positive-averse)
+  * sanity check: posts that would fire at the recommended threshold
+
+The goal is to replace the current vibes-based matching_threshold=0.72
+with an empirically-grounded number for each workspace's data.
+See issue #106 for context.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import text  # noqa: E402
+from app.database import get_db  # noqa: E402
+
+
+# ---------- Phase 1 — export labeling doc ---------------------------------
+
+LABELING_HEADER = """# Sonar — Matching Calibration: Labeling Doc
+
+**Workspace:** `{workspace_id}`
+**Generated:** {generated_at}
+**Posts:** {post_count}  |  **Signals (enabled):** {signal_count}
+
+## Instructions
+
+For each post below, decide: **if I were the user of this workspace, would I
+want Sonar to alert me about this post as a buying-intent signal?**
+
+- `[x]` = yes, this is a real intent signal I'd want to see
+- `[ ]` = no, this is noise / irrelevant / off-topic
+- Leave the `reason` field blank unless the judgment is non-obvious
+
+Do NOT overthink edge cases — first-gut label is the most calibrated. The
+analyzer computes F1 and F0.5 at every threshold, so a few ambiguous labels
+won't skew results.
+
+Posts are sorted by their current max-cosine against any signal (descending),
+so the most "relevant by the model" posts come first.
+
+---
+
+"""
+
+LABELING_ENTRY = """## Post {index} — max_cosine = {max_cos:.3f}
+
+**Top-3 matching signals:**
+{top_signals}
+
+**Content:**
+
+```
+{content}
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: {post_id} -->
+
+---
+
+"""
+
+
+@dataclass
+class PostSignalRow:
+    post_id: str
+    content: str
+    top_signals: list[tuple[str, float]]  # [(phrase, cosine), ...]
+    max_cosine: float
+
+
+async def fetch_post_signal_data(workspace_id: UUID) -> list[PostSignalRow]:
+    """Fetch each post with its top-3 highest-cosine signals."""
+    query = text(
+        """
+        WITH pairs AS (
+          SELECT p.id AS post_id,
+                 p.content AS content,
+                 s.phrase AS phrase,
+                 1 - (p.embedding <=> s.embedding) AS cosine,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY p.id
+                   ORDER BY (p.embedding <=> s.embedding)
+                 ) AS rnk
+          FROM posts p
+          CROSS JOIN signals s
+          WHERE p.workspace_id = :wsid
+            AND p.embedding IS NOT NULL
+            AND s.workspace_id = :wsid
+            AND s.enabled
+            AND s.embedding IS NOT NULL
+        )
+        SELECT post_id, content, phrase, cosine, rnk
+        FROM pairs
+        WHERE rnk <= 3
+        ORDER BY post_id, rnk
+        """
+    )
+
+    async for db in get_db():
+        result = await db.execute(query, {"wsid": str(workspace_id)})
+        rows = result.all()
+        break
+
+    grouped: dict[str, PostSignalRow] = {}
+    for post_id, content, phrase, cosine, rnk in rows:
+        key = str(post_id)
+        if key not in grouped:
+            grouped[key] = PostSignalRow(
+                post_id=key, content=content, top_signals=[], max_cosine=0.0
+            )
+        grouped[key].top_signals.append((phrase, float(cosine)))
+        if float(cosine) > grouped[key].max_cosine:
+            grouped[key].max_cosine = float(cosine)
+
+    return sorted(grouped.values(), key=lambda r: -r.max_cosine)
+
+
+async def cmd_export(workspace_id: UUID, out_path: Path) -> None:
+    from datetime import datetime, timezone
+
+    rows = await fetch_post_signal_data(workspace_id)
+
+    signal_count_query = text(
+        "SELECT COUNT(*) FROM signals WHERE workspace_id = :wsid AND enabled"
+    )
+    async for db in get_db():
+        signal_count = (
+            await db.execute(signal_count_query, {"wsid": str(workspace_id)})
+        ).scalar_one()
+        break
+
+    doc = LABELING_HEADER.format(
+        workspace_id=workspace_id,
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        post_count=len(rows),
+        signal_count=signal_count,
+    )
+
+    for idx, row in enumerate(rows, start=1):
+        top_signals_md = "\n".join(
+            f"- `{phrase}` (cosine {cos:.3f})" for phrase, cos in row.top_signals
+        )
+        doc += LABELING_ENTRY.format(
+            index=idx,
+            post_id=row.post_id,
+            max_cos=row.max_cosine,
+            top_signals=top_signals_md,
+            content=row.content.strip(),
+        )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(doc)
+    print(f"[calibrate] wrote {len(rows)} posts to {out_path}")
+    print(
+        "[calibrate] next: edit the file, change `[ ]` to `[x]` for real matches, then run `analyze`"
+    )
+
+
+# ---------- Phase 2 — analyze labels --------------------------------------
+
+LABEL_RE = re.compile(
+    r"\*\*Label:\*\*\s*`\[(?P<mark>[ xX])\]`.*?<!-- label-id: (?P<pid>[a-f0-9\-]+) -->",
+    re.DOTALL,
+)
+
+
+def parse_labels(labels_path: Path) -> dict[str, bool]:
+    """Extract {post_id: is_match_bool} from the filled labeling doc."""
+    doc = labels_path.read_text()
+    labels: dict[str, bool] = {}
+    for match in LABEL_RE.finditer(doc):
+        pid = match.group("pid").strip()
+        mark = match.group("mark").strip().lower()
+        labels[pid] = mark == "x"
+    return labels
+
+
+async def fetch_max_cosine_per_post(workspace_id: UUID) -> dict[str, float]:
+    """For each post, return its max cosine across all enabled signals."""
+    query = text(
+        """
+        SELECT p.id::text AS post_id,
+               MAX(1 - (p.embedding <=> s.embedding)) AS max_cos
+        FROM posts p
+        CROSS JOIN signals s
+        WHERE p.workspace_id = :wsid
+          AND p.embedding IS NOT NULL
+          AND s.workspace_id = :wsid
+          AND s.enabled
+          AND s.embedding IS NOT NULL
+        GROUP BY p.id
+        """
+    )
+    async for db in get_db():
+        result = await db.execute(query, {"wsid": str(workspace_id)})
+        rows = result.all()
+        break
+    return {pid: float(cos) for pid, cos in rows}
+
+
+def compute_metrics_at_threshold(
+    cosines: list[float], labels: list[bool], threshold: float
+) -> dict[str, float]:
+    """Compute precision, recall, F1, F0.5 at a single threshold."""
+    tp = fp = fn = tn = 0
+    for cos, label in zip(cosines, labels):
+        predicted_match = cos >= threshold
+        if predicted_match and label:
+            tp += 1
+        elif predicted_match and not label:
+            fp += 1
+        elif not predicted_match and label:
+            fn += 1
+        else:
+            tn += 1
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    # F0.5 weighs precision 2× recall — use when false positives cost more
+    # than misses (typical for alert-style products).
+    f_half = (
+        1.25 * precision * recall / (0.25 * precision + recall)
+        if (0.25 * precision + recall)
+        else 0.0
+    )
+    return {
+        "threshold": threshold,
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        "tn": tn,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "f0_5": f_half,
+    }
+
+
+def print_distribution(cosines: list[float], labels: list[bool]) -> None:
+    match_cos = sorted([c for c, lb in zip(cosines, labels) if lb])
+    nonmatch_cos = sorted([c for c, lb in zip(cosines, labels) if not lb])
+
+    print(f"\n=== cosine distribution ({len(cosines)} posts labeled) ===")
+    print(f"matches    n={len(match_cos):3d}  ", end="")
+    if match_cos:
+        print(
+            f"min={min(match_cos):.3f} p25={_pct(match_cos, 25):.3f} "
+            f"median={_pct(match_cos, 50):.3f} p75={_pct(match_cos, 75):.3f} "
+            f"max={max(match_cos):.3f}"
+        )
+    else:
+        print("(none — all posts labeled non-match; calibration not possible)")
+    print(f"non-match  n={len(nonmatch_cos):3d}  ", end="")
+    if nonmatch_cos:
+        print(
+            f"min={min(nonmatch_cos):.3f} p25={_pct(nonmatch_cos, 25):.3f} "
+            f"median={_pct(nonmatch_cos, 50):.3f} p75={_pct(nonmatch_cos, 75):.3f} "
+            f"max={max(nonmatch_cos):.3f}"
+        )
+    else:
+        print("(none — all posts labeled match)")
+
+    if match_cos and nonmatch_cos:
+        overlap_lo = max(min(match_cos), min(nonmatch_cos))
+        overlap_hi = min(max(match_cos), max(nonmatch_cos))
+        if overlap_lo <= overlap_hi:
+            print(
+                f"overlap zone: [{overlap_lo:.3f}, {overlap_hi:.3f}] — "
+                "thresholds in this range will misclassify either direction"
+            )
+        else:
+            print("distributions are SEPARABLE — any threshold in the gap is perfect")
+
+
+def _pct(sorted_list: list[float], pct: float) -> float:
+    if not sorted_list:
+        return 0.0
+    idx = int(len(sorted_list) * pct / 100)
+    idx = max(0, min(idx, len(sorted_list) - 1))
+    return sorted_list[idx]
+
+
+def print_sweep(cosines: list[float], labels: list[bool]) -> dict[str, dict]:
+    print("\n=== threshold sweep ===")
+    print(
+        f"{'thr':>6}  {'TP':>3} {'FP':>3} {'FN':>3} {'TN':>3}  "
+        f"{'P':>5} {'R':>5} {'F1':>5} {'F0.5':>5}"
+    )
+
+    best_f1 = {"f1": -1.0}
+    best_f0_5 = {"f0_5": -1.0}
+    rows = []
+    for i in range(0, 101):
+        thr = i / 100
+        m = compute_metrics_at_threshold(cosines, labels, thr)
+        rows.append(m)
+        if m["f1"] > best_f1.get("f1", -1):
+            best_f1 = m
+        if m["f0_5"] > best_f0_5.get("f0_5", -1):
+            best_f0_5 = m
+
+    # Print a sampled subset to keep output readable
+    printed = set()
+    for m in rows:
+        step = m["threshold"]
+        if step in printed:
+            continue
+        # every 0.05 + any that are at best-F1 or best-F0.5
+        if abs((step * 20) - round(step * 20)) < 1e-6 or m is best_f1 or m is best_f0_5:
+            marker = ""
+            if m is best_f1:
+                marker += " ← max F1"
+            if m is best_f0_5:
+                marker += " ← max F0.5"
+            print(
+                f"{m['threshold']:>6.2f}  "
+                f"{m['tp']:>3} {m['fp']:>3} {m['fn']:>3} {m['tn']:>3}  "
+                f"{m['precision']:>5.2f} {m['recall']:>5.2f} "
+                f"{m['f1']:>5.2f} {m['f0_5']:>5.2f}{marker}"
+            )
+            printed.add(step)
+
+    return {"best_f1": best_f1, "best_f0_5": best_f0_5}
+
+
+async def cmd_analyze(workspace_id: UUID, labels_path: Path) -> None:
+    labels_map = parse_labels(labels_path)
+    if not labels_map:
+        print(
+            f"[calibrate] no label markers found in {labels_path}. "
+            "Expected `**Label:** `[x]`` + `<!-- label-id: <uuid> -->` pairs."
+        )
+        sys.exit(1)
+
+    cosines_map = await fetch_max_cosine_per_post(workspace_id)
+    if not cosines_map:
+        print("[calibrate] no posts with embeddings found for this workspace.")
+        sys.exit(1)
+
+    paired = [
+        (cosines_map[pid], labels_map[pid]) for pid in labels_map if pid in cosines_map
+    ]
+    unmatched = set(labels_map) - set(cosines_map)
+    if unmatched:
+        print(
+            f"[calibrate] warning: {len(unmatched)} labeled posts not found in DB "
+            "(skipped). possible IDs drifted since export."
+        )
+
+    cosines = [p[0] for p in paired]
+    labels = [p[1] for p in paired]
+    match_count = sum(labels)
+
+    print(f"\nloaded {len(paired)} labeled posts for workspace {workspace_id}")
+    print(
+        f"  matches: {match_count} ({match_count / len(paired):.0%})   "
+        f"non-matches: {len(paired) - match_count}"
+    )
+
+    print_distribution(cosines, labels)
+    bests = print_sweep(cosines, labels)
+
+    print("\n=== recommendations ===")
+    f1 = bests["best_f1"]
+    fh = bests["best_f0_5"]
+    print(
+        f"max F1 @ cosine {f1['threshold']:.2f}  "
+        f"(P={f1['precision']:.2f} R={f1['recall']:.2f} F1={f1['f1']:.2f})"
+    )
+    print(
+        f"max F0.5 @ cosine {fh['threshold']:.2f}  "
+        f"(P={fh['precision']:.2f} R={fh['recall']:.2f} F0.5={fh['f0_5']:.2f})"
+    )
+    print(
+        "\nFor alert-style products (false positives cost more than misses),"
+        " F0.5 is usually the right objective."
+    )
+    print(
+        "\nNOTE: the recommended values are thresholds on MAX RING-2 COSINE"
+        " per post, not on combined_score. To translate to combined_score,"
+        " multiply by 0.5 (relevance weight) and add the expected"
+        " relationship+timing contribution."
+    )
+
+
+# ---------- main ---------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="cmd", required=True)
+
+    ex = subparsers.add_parser("export", help="export labeling doc")
+    ex.add_argument("--workspace-id", type=UUID, required=True)
+    ex.add_argument("--out", type=Path, required=True)
+
+    an = subparsers.add_parser("analyze", help="analyze filled-in labels")
+    an.add_argument("--workspace-id", type=UUID, required=True)
+    an.add_argument("--labels", type=Path, required=True)
+
+    args = parser.parse_args()
+    if args.cmd == "export":
+        asyncio.run(cmd_export(args.workspace_id, args.out))
+    elif args.cmd == "analyze":
+        asyncio.run(cmd_analyze(args.workspace_id, args.labels))
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/calibration/dogfood-martech-agency.md
+++ b/eval/calibration/dogfood-martech-agency.md
@@ -1,0 +1,1138 @@
+# Sonar — Matching Calibration: Labeling Doc
+
+**Workspace:** `eb23b44f-88ea-4a94-88ae-b9aca2d66345`
+**Generated:** 2026-04-20 11:46 UTC
+**Posts:** 30  |  **Signals (enabled):** 10
+
+## Instructions
+
+For each post below, decide: **if I were the user of this workspace, would I
+want Sonar to alert me about this post as a buying-intent signal?**
+
+- `[x]` = yes, this is a real intent signal I'd want to see
+- `[ ]` = no, this is noise / irrelevant / off-topic
+- Leave the `reason` field blank unless the judgment is non-obvious
+
+Do NOT overthink edge cases — first-gut label is the most calibrated. The
+analyzer computes F1 and F0.5 at every threshold, so a few ambiguous labels
+won't skew results.
+
+Posts are sorted by their current max-cosine against any signal (descending),
+so the most "relevant by the model" posts come first.
+
+---
+
+## Post 1 — max_cosine = 0.475
+
+**Top-3 matching signals:**
+- `Rebuilding our marketing automation stack` (cosine 0.475)
+- `Scaling performance marketing efficiently` (cosine 0.440)
+- `Modernizing our digital growth engine` (cosine 0.417)
+
+**Content:**
+
+```
+🚀 How Acer Reduced Cart Abandonment and Boosted Revenue with Our Smart Marketing Automation Tool NotifyVisitors.
+
+Acer Inc., one of the world's largest computer manufacturers, faced challenges in reducing cart abandonment, enhancing customer engagement, and improving conversion rates. But with the help of NotifyVisitors, they implemented a powerful marketing automation strategy that delivered incredible results. Here's how they did it:
+
+✅ Key Objectives:
+
+1.  Reduce Cart Abandonment 🛒
+2.  Increase Revenue & Engagement 📈
+3.  Boost Conversion Rates 💰
+
+🔑 Solutions Implemented:
+
+1.  Omni-Channel Campaigns: Engaged customers via SMS, email, and WhatsApp for consistent communication across touchpoints.
+
+2.  Customized Messaging: Behavior-based automated messages reminding customers of abandoned carts, with exclusive discounts to encourage conversions.
+
+3.  Engagement Strategies: Used compelling visuals and relevant product info to capture attention and re-engage potential buyers.
+
+📈 Results:
+
+1.  35% reduction in cart abandonment
+2.  12% increase in revenue in just 2 months
+3.  90% delivery rate for WhatsApp campaigns, with 82% open rates on automated messages
+
+The takeaway? Personalized, omni-channel marketing automation can significantly reduce cart abandonment and increase sales. 🚀
+
+Would you be ready to boost your e-commerce sales? Let’s connect and explore how these strategies can work for your brand!
+
+https://lnkd.in/dE37D7JH
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 51730b24-44d2-41fd-b500-484b1904fd00 -->
+
+---
+
+## Post 2 — max_cosine = 0.470
+
+**Top-3 matching signals:**
+- `Rebuilding our marketing automation stack` (cosine 0.470)
+- `Modernizing our digital growth engine` (cosine 0.449)
+- `Scaling performance marketing efficiently` (cosine 0.441)
+
+**Content:**
+
+```
+🚀 How Just Herbs Boosted Customer Engagement & Revenue Using Our Smart Marketing Automation Tool NotifyVisitors
+
+Just Herbs, a global Ayurvedic beauty brand, turned its marketing strategy around using NotifyVisitors to achieve impressive results. By focusing on personalized communication and data-driven insights, they achieved:
+
+✅ Key Objectives:
+1. Improve campaign performance for a better marketing strategy
+2. Increase brand awareness and engagement
+3. Reduce cart abandonment and boost customer retention
+4. Improve conversion rates for higher revenue
+
+🔑 Solutions Implemented:
+
+1. Accurate Campaign Analytics: Measured delivery, open rates, and revenue to optimize marketing strategies.
+2. Journey Builder: Created targeted, multi-channel campaigns across SMS, email, and web push notifications.
+3. Segmentation: Developed user segments based on activity and customer personas for personalized messaging.
+4. Real-Time Data Tracking: Tracked customer interactions across devices for seamless and personalized communication.
+5. Web Push Notifications: Engaged customers even when they weren’t browsing the site.
+
+📈 Results:
+1. 100% growth in customer base
+2. 25% of revenue generated through campaigns
+3. 55% delivery rate for web push notifications
+4. 200% increase in open rates via automated emails
+
+The takeaway? Data-driven strategies + automation = massive e-commerce growth. 🚀
+
+Ready to scale your e-commerce brand? Let’s connect and explore how these strategies can work for you!
+
+https://lnkd.in/ddND5gYA
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: a0a90d6e-1a12-4c46-aaf1-6a71d0554ad1 -->
+
+---
+
+## Post 3 — max_cosine = 0.432
+
+**Top-3 matching signals:**
+- `Scaling performance marketing efficiently` (cosine 0.432)
+- `Rebuilding our marketing automation stack` (cosine 0.375)
+- `Modernizing our digital growth engine` (cosine 0.368)
+
+**Content:**
+
+```
+This wasn’t a game. It was a lead-generation machine disguised as fun.
+
+At Inorbit Mall, I played a simple “Reindeer Ring Toss.”
+Five rings. Three hits gets you food vouchers you can redeem right there in the mall.
+
+But before the first ring left your hand, something more valuable was collected.
+Your WhatsApp number. Your details. Your permission.
+
+Within an hour, the promotional messages started.
+
+From a marketing lens, this setup is quietly brilliant.
+
+They traded low-cost physical rewards for high-intent first-party data.
+The vouchers ensured redemption stayed inside the mall ecosystem.
+The game created emotional engagement, not ad fatigue.
+And WhatsApp ensured near-100% open rates post interaction.
+
+No cold ads. No CPMs. No attribution headache.
+
+This is offline-to-online performance marketing done right.
+Acquire attention physically. Convert digitally. Retarget directly.
+
+What’s interesting is not the game. It’s the timing and the channel.
+You didn’t feel sold to. You felt rewarded.
+By the time the messages arrived, consent was already emotionally granted.
+
+In a world where ad costs are rising and tracking is breaking, this is the playbook brands should study.
+Create moments, not impressions.
+Capture intent, not clicks.
+And move users from fun to funnel without them noticing the transition.
+
+Marketing didn’t interrupt my mall visit.
+It embedded itself inside it.
+
+And that’s the part worth paying attention to.
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: b570240f-c527-4556-94ec-e3777e0beffe -->
+
+---
+
+## Post 4 — max_cosine = 0.424
+
+**Top-3 matching signals:**
+- `Rebuilding our marketing automation stack` (cosine 0.424)
+- `Evaluating a martech partner` (cosine 0.404)
+- `Modernizing our digital growth engine` (cosine 0.395)
+
+**Content:**
+
+```
+Over the past few months, I’ve spent a lot of time actually studying/using AI across content, performance and product marketing.
+
+Not just reading about it. Not just testing prompts. But building, iterating, failing, refining.
+
+I also made a conscious effort to go deeper. I connected with folks working in AI, spent weekends attending workshops, and explored tools hands-on.
+
+And here’s what I’ve boiled it down to:
+
+There’s a lot of noise around AI. Rightly so. Some are still learning it, some are in pilot mode, and some have gone all in. But from a product marketing and growth lens, a few things are clear.
+
+AI has brought in herculean efficiency, but shies away from the final outcome. What used to take days now takes hours, and weeks become days. Yet the output is still not final-ready. AI gets you 70 steps ahead, but the last 30 still needs human intervention. And that last 30 is where quality lies.
+
+Creative strategy and execution have shifted. You can generate multiple routes, scripts and ideas in minutes. But abundance, at times , creates sameness. The real judgement is picking the right direction and executing it better than everyone else.
+
+Writing with AI still needs effort. It writes well, and feels right in the first go. But emotional aspects, cultural nuance and lived experiences are still missing. You get there through iterations and the right context.
+
+Visuals and videos are faster. Storyboards, mockups and concepts are faster too. But continuity, detailing, brand aesthetics and final polish still needs supervision, despite having a QC skill in three different trained, AI models.
+
+AI has made generalists stronger and  specialists all the more powerful. Without domain depth, output becomes, what I call as "polished confusion". It looks right, sounds right, but may lack relevance.
+
+Hallucination and inconsistency are major problems. AI loses context and produces different outputs. Without a clear source of truth and guardrails, things can go haywire and you end up wasting hours.
+
+You also don’t need 50 tools. A narrowed down stack works better. Use them in conjunction.
+
+Performance marketing has quietly changed. CTR, CPC and CPA still matter, but they are not enough.Discovery, Influence and Decisioning has changed.
+
+SEO is no longer standalone. AEO and GEO are the driving levers.
+
+Brand consistency is non-negotiable. Without a clear brand voice, visual language and guardrails, outputs will trouble across touchpoints.
+
+In my view, AI has reduced effort and improved Time to Market. AI will do the lifting, but humans (SMEs) will decide what’s worth lifting. That difference will define outcomes. Else, we are already seeing similar outputs in various industries/arena with only different logos.
+
+PS: AI hasn’t been recruited to write this. I haven’t outsourced my critical thinking, logical deduction or writing yet.
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 7944963c-81b5-4a11-bc3a-3c63593ae809 -->
+
+---
+
+## Post 5 — max_cosine = 0.404
+
+**Top-3 matching signals:**
+- `Evaluating a martech partner` (cosine 0.404)
+- `Modernizing our digital growth engine` (cosine 0.399)
+- `Rebuilding our marketing automation stack` (cosine 0.363)
+
+**Content:**
+
+```
+I launched a side project this weekend. getmetrik.com
+
+Honestly, it started as curiosity.
+
+Everyone was talking about Claude Code and Cursor. I kept bookmarking threads, telling myself, I'll try it someday. Three weeks ago, someday arrived. What I didn't expect: I'd actually ship something. And buy a domain. And give it a name.
+
+Metrik is a growth audit tool for early-stage founders. Upload your event CSV, tell it your stage and what decision you're facing, get a retention pattern, benchmark comparison, and 3 experiments to run. In 60 seconds.
+
+I picked this problem because I've spent time in analytics and kept seeing the same gap: founders have data, but not the context to act on it.
+
+Building it was genuinely fun. Git setup, merging branches, integrations and deployment. And it's very addictive, to be honest.
+
+A few things I learned:
+
+Building is the easy part. Telling people about it is a whole other skill set. SaaS marketing influencers make it look simple. They are lying, or very talented, possibly both.
+
+Also, keeping up with AI while building on weekends is a special kind of chaos.
+
+If you're an early-stage founder trying to make sense of your retention data, try it and tell me what's broken.
+
+Be gentle, API credits might vanish sooner than you think.
+
+getmetrik.com - Free, no sign-up needed.
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: aa1c0440-9d7d-4a3c-b910-d0b2bc058445 -->
+
+---
+
+## Post 6 — max_cosine = 0.380
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.380)
+- `Need better lifecycle personalization` (cosine 0.256)
+- `Evaluating a martech partner` (cosine 0.252)
+
+**Content:**
+
+```
+Dropping by to share a #CareerUpdate
+
+A new beginning, slightly ahead of the new year!
+
+I’ve joined Indiluxe by Tata Cliq Luxury to work on a space that brings together everything I’m personally excited about: #Indian, #homegrown, #luxe, and #designerled brands.
+
+The last two months navigating this new role while also transitioning base to Mumbai has been challenging in the best way.
+
+Excited for what this year holds - more challenges, sharper learnings, and meaningful wins 🤞🏻
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 394f152d-9f5b-4ca3-8928-7a33e8ef5051 -->
+
+---
+
+## Post 7 — max_cosine = 0.373
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.373)
+- `Need better lifecycle personalization` (cosine 0.298)
+- `Need to unify our customer data` (cosine 0.296)
+
+**Content:**
+
+```
+In a fast-moving world, staying ahead is everything.
+
+Your banking should move with you — and rise with you.
+
+Banking that rises with your lifestyle.
+
+#UtkarshSmallFinanceBank #Banking #AapkiUmmeedKaKhaata #CustomerFirst #BankingInnovation #FinancialGrowth #PremiumBanking #LifestyleBanking #Growth #Trust
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: d86e462c-dfd9-4086-9257-f9f9f75e232a -->
+
+---
+
+## Post 8 — max_cosine = 0.354
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.354)
+- `Evaluating a martech partner` (cosine 0.344)
+- `Scaling performance marketing efficiently` (cosine 0.322)
+
+**Content:**
+
+```
+Growing up watching MS, his calm demeanor and grounded perspective always fascinated me. Naturally, when a brand brings him on board, I look under the hood to understand the strategy.
+
+As a marketing professional in the banking sector, I see how saturated the digital payments ecosystem is. The typical financial playbook screams aspiration. This BHIM campaign does the exact opposite. It whispers trust.
+
+Here is why this positioning cuts through the market clutter perfectly:
+
+• The brief was not about buying empty reach. For unconverted UPI users, the primary barrier is no longer brand awareness. It is transaction anxiety.
+
+• Dhoni isn't aspirational for Tier 2/3 India; he's familiar. He's from a small town, he's quietly dependable, and he's never needed noise to make a point. That's exactly the energy BHIM needed to address the one real barrier in the UPI market: not awareness, but trust.
+
+• The creative execution keeps it grounded. A kirana store. A confused customer. A simple recommendation. No stadium. No trophy. Just Mahi, standing next to the fridge, telling you it's safe.
+
+• The tagline "It's the Mahi way" lets his earned equity do the heavy lifting. Pairing this massive trust signal with a simple 20 rupees cashback trigger drives immediate user adoption.
+
+The real strategic win goes far beyond surface level celebrity endorsement. While MS Dhoni brings massive visibility, BHIM did not just rent his fame for mere eyeballs. They seamlessly aligned their core product promise with the intrinsic values of their ambassador.
+
+In a category where trust is the absolute ultimate currency, choosing the one person in Indian cricket who embodies flawless execution under pressure is exactly how you build a resilient legacy brand.
+
+NPCI BHIM #UPI #BrandStrategy #MarketingAnalysis #DigitalPayments #NPCI
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 71b1eee7-1515-460d-8cd0-b348e74ae695 -->
+
+---
+
+## Post 9 — max_cosine = 0.345
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.345)
+- `Evaluating a martech partner` (cosine 0.318)
+- `Rebuilding our marketing automation stack` (cosine 0.240)
+
+**Content:**
+
+```
+𝗘𝘃𝗲𝗿𝘆 𝗶𝗻𝘃𝗲𝘀𝘁𝗼𝗿 𝘄𝗿𝗶𝘁𝗲𝘀 𝗮 𝗰𝗵𝗲𝗾𝘂𝗲 𝗳𝗼𝗿 𝗮 𝘀𝘁𝗼𝗿𝘆, 𝗻𝗼𝘁 𝗷𝘂𝘀𝘁 𝗮 𝗻𝘂𝗺𝗯𝗲𝗿.
+
+On Bharat ke Super Founders, Ajay Lakhotia, Founder StockGro sat down with Jeetendra Lalwani, Founder of Dial4242 Ambulances, and decoded something most founders miss completely.
+
+Price is never the pitch. The narrative behind it is.
+
+Smart investors do not just evaluate revenue. They evaluate how deeply you understand your customer, your market, and your own worth. That is what separates a fundable startup from a forgettable one.
+
+Jeetendra is building something rare in India's healthcare space. An ambulance network that runs on urgency, trust, and scale.
+
+𝗔𝗻𝗱 𝗵𝗶𝘀 𝘀𝘁𝗼𝗿𝘆?
+
+It is exactly what sharp investors lean forward for.
+
+This masterclass episode on Amazon MX Player is not just a conversation. It is a blueprint for every founder who wants to walk into a room and command attention.
+
+𝗪𝗮𝘁𝗰𝗵 𝗶𝘁. 𝗔𝗽𝗽𝗹𝘆 𝘁𝗵𝗲 𝗹𝗲𝗻𝘀. 𝗧𝗵𝗲𝗻 𝗽𝗶𝘁𝗰𝗵 𝗱𝗶𝗳𝗳𝗲𝗿𝗲𝗻𝘁𝗹𝘆.
+
+Debajyoti Jena, Founder The StartUp Circle is proud to spotlight bold founders like Ajay Lakhotia who are reshaping traditional industries with technology, vision, and conviction.
+
+What is the one narrative shift that changed how investors looked at your startup?
+
+Connect - Debajyoti
+Follow      - The StartUp Circle
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 0a98425e-5bd3-48ae-9f17-ad92a28ec119 -->
+
+---
+
+## Post 10 — max_cosine = 0.342
+
+**Top-3 matching signals:**
+- `Evaluating a martech partner` (cosine 0.342)
+- `Modernizing our digital growth engine` (cosine 0.317)
+- `Rebuilding our marketing automation stack` (cosine 0.270)
+
+**Content:**
+
+```
+every morning i wake up to startups raising tens of millions for incredible ideas like
+> meeting note taker
+> copilots for copilots
+> revenue agent
+> agents pay to chat
+> software to build software
+
+and yet another idea-to-app slop. seriously, how can someone be bullish on these?
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: ec462040-02c8-4986-891f-94a1aa3ae104 -->
+
+---
+
+## Post 11 — max_cosine = 0.335
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.335)
+- `Evaluating a martech partner` (cosine 0.321)
+- `Rebuilding our marketing automation stack` (cosine 0.306)
+
+**Content:**
+
+```
+Glad to share that I made it to the President's Club at MoEngage for the 4th year in a row!
+
+Huge thanks to the extended team & Shivangi Boghani Narasimha Rao Yash Reddy Raviteja Dodda Narasimha Reddy Yashwanth Kumar for their support.
+
+I am proud of our execution rigour & continued strong momentum over the years. Looking forward to 2026! 🏆
+
+#SalesLife #AIPoweredCustomerEngagement #MoEngage
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 827789f2-e1ff-4829-8ab2-f1d2bdd71973 -->
+
+---
+
+## Post 12 — max_cosine = 0.326
+
+**Top-3 matching signals:**
+- `Evaluating a martech partner` (cosine 0.326)
+- `Modernizing our digital growth engine` (cosine 0.286)
+- `Fixing analytics governance` (cosine 0.241)
+
+**Content:**
+
+```
+𝗔𝗿𝗲 𝘆𝗼𝘂 𝗮 𝗙𝗼𝘂𝗻𝗱𝗲𝗿 / 𝗜𝗻𝘃𝗲𝘀𝘁𝗼𝗿 / 𝗦𝘁𝗮𝗿𝘁-𝘂𝗽 𝗘𝗻𝘁𝗵𝘂𝘀𝗶𝗮𝘀𝘁 ?
+
+𝗜 𝗮𝗺 𝗷𝗼𝗶𝗻𝗶𝗻𝗴 𝗩𝗖 𝗖𝗼𝗻𝗳𝗲𝗿𝗲𝗻𝗰𝗲 𝗼𝗻 𝟯𝟭𝘀𝘁 𝗠𝗮𝗿𝗰𝗵.
+
+Here you can join (FREE) 5,600+ Founders & Investors who’ve registered for the Virtual VC Conf on March 31 (Zoom + stream).
+
+𝗦𝘁𝗮𝘁𝘀:-
+
+𝟴𝟱𝟵 𝗜𝗻𝘃𝗲𝘀𝘁𝗼𝗿𝘀:- 426 VC Funds, 331 Angels & HNWIs, 110 Family Offices, 152 LPs, 114 secondary investors. Average check - $2,004,340, Median – $275K.
+
+3,232 startups with 1,089 pitch decks already submitted.
+
+552 Fundraising Advisors, Incl. 260 without retainers.
+
+👉   𝗦𝗲𝗻𝗱 𝗺𝗲 𝗮 𝗖𝗼𝗻𝗻𝗲𝗰𝘁𝗶𝗼𝗻 𝗥𝗲𝗾𝘂𝗲𝘀𝘁 (Debajyoti) & 𝗖𝗼𝗺𝗺𝗲𝗻𝘁 “𝗩𝗖 𝗖𝗼𝗻𝗳𝗲𝗿𝗲𝗻𝗰𝗲”, 𝗦𝗼 𝗜 𝗰𝗮𝗻 𝗗𝗠 𝘆𝗼𝘂 𝘁𝗵𝗲 𝗟𝗶𝗻𝗸.
+
+70+ Zoom breakout rooms for 5 hours of networking hosted by 170+ Active Investors.
+
+30+ speakers with hundreds of VC insights, 6+ hours
+
+1. What the early 2026 data about early-stage funding says to VCs & Founders - Peter Walker.
+
+2. How AI can help Founders reach the right investors faster?
+
+Andrew D'Souza (10,000+ Founders Funded)
+
+3. Why 99% of AI startups are not fundable? What AI should founders focus on?
+
+Sue Xu ($1B+ AUM, 17 Unicorns), Valère Rames (15 Unicorns), Leah Eliz ($500M+)
+
+4. Inside investor's deal funnel: How VC funds evaluate seed startups?
+
+Eric Theis ($750M), Ellen Chisa ($1.1Bn+), Ugne Musneckyte (€100M+), Moderator - Shaun Gold.
+
+5. Best practices for raising your first VC round - Itamar Novick (100+ deals).
+
+6. Early-Stage Investment & Fundraising trends 2026:-
+
+Ron Levin ($1.5B, founder of Perk), Joseph Ros - Entrepreneurs First (600+ deals), Karen Page ($11B+), Moderator - Merisha Stevenson - BBC.
+
+7. Early-Stage Funding beyond VC funds: Accelerators, Venture Studios & Angel Syndicates:-
+
+David Cohen (5,000+ deals), T. A. McCann, Matt Ridenour - Google DeepMind, Moderator - Nick Moran.
+
+8. How to go from idea to a product your customers will love, get investment ready, and close your next round.
+
+Anthony Rose - SeedLegals (£2.5B+ Raised, 50K+ Customers).
+
+9. Underrated AI bets that will actually create $1B+ companies - Andrew Brackin, Gradient ($1B+)
+
+10. Top red flags & green lights when Angels & first-check VCs look at Pre-Seed Startups:-
+
+Charles Hudson ($250M, 450+ Deals), Khalil Fuller ($800M, 7+ Unicorns), Tim Suzman (923 deals).
+
+11. Go International Day 1, Start locally, or Focus on the US market?
+
+Allen Taylor ($500M+, 70+ unicorns), Payton Dobbs ($215M).
+
+12. Learnings from 50+ Angel Investments:- Should you become an LP or Invest directly?
+
+Scott Hartley (300+ Pre-Seed deals), Charles ▫️ Delingpole (180+ Angel Deals).
+
+13. The cap table problem: Do venture studios make startups un investable for VCs?
+
+Matthew Burris (1,500+ members, 48B+), Brad Wisler
+
+14. Leverage AI to be a 10x Founder - John Frankel ($300M+, 160+ Deals).
+
+Post & VC Conference Host Credit - Max Pog
+
+For More, Connect - Debajyoti & Follow The StartUp Circle.
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 126f446d-135b-4ad1-9f6e-564776abb292 -->
+
+---
+
+## Post 13 — max_cosine = 0.324
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.324)
+- `Evaluating a martech partner` (cosine 0.290)
+- `Rebuilding our marketing automation stack` (cosine 0.252)
+
+**Content:**
+
+```
+Moving to Bengaluru changed things for me!
+
+One thing that hit me instantly was that meeting people isn’t hard, meeting the right people is.
+
+That's when I came across The League. It has some unique features like waitlist, vetted profiles, selected matches and that actually made sense. It filters for people who are clear about what they want.
+
+Around the same time, I noticed their mirrors across the city at places like gyms, coffee spots, padel courts with lines like:
+
+“I push too hard.”
+“I always keep score.”
+
+It stole my attention instantly because those aren’t red flags. That’s just ambition, standards, personality and things most people are told to tone down.
+
+What they’ve done well is simple by building a product for high-intent people, and market it exactly where those people already are.
+
+And honestly, that applies to a lot more than dating!
+
+#Dating #Connecting #Collab
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: f6f91015-fae6-44e4-88f2-a14ba84f00b2 -->
+
+---
+
+## Post 14 — max_cosine = 0.301
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.301)
+- `Evaluating a martech partner` (cosine 0.208)
+- `Fixing analytics governance` (cosine 0.189)
+
+**Content:**
+
+```
+Happy to share that I have successfully completed the 𝐂𝐞𝐫𝐭𝐢𝐟𝐢𝐜𝐚𝐭𝐞 𝐂𝐨𝐮𝐫𝐬𝐞 𝐢𝐧 𝐒𝐭𝐫𝐚𝐭𝐞𝐠𝐢𝐜 𝐌𝐚𝐧𝐚𝐠𝐞𝐦𝐞𝐧𝐭 & 𝐈𝐧𝐧𝐨𝐯𝐚𝐭𝐢𝐨𝐧𝐬 𝐢𝐧 𝐁𝐚𝐧𝐤𝐢𝐧𝐠 from the Indian Institute of Banking & Finance (IIBF).
+
+This program enhanced my understanding of strategic thinking, innovation, and the evolving digital landscape in the banking sector. Looking forward to applying these insights to drive better product and digital transformation initiatives in BFSI.
+
+#IIBF #Banking #StrategicManagement #Innovation #BFSI #Learning
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 685cf182-90f3-4b59-a88e-f170a8e8602e -->
+
+---
+
+## Post 15 — max_cosine = 0.279
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.279)
+- `Evaluating a martech partner` (cosine 0.249)
+- `Need better lifecycle personalization` (cosine 0.248)
+
+**Content:**
+
+```
+Parenting is full of small, everyday decisions.
+
+Sometimes it’s a last-minute essential. Sometimes it’s something your child decides they can’t do without. These are the moments we had in mind while building OZi, bringing everything parents need into one place, to make those decisions simpler and more convenient.
+
+Welcoming Parineeti Chopra as OZi’s brand ambassador felt like a natural step in telling that story.
+
+Proud of the team for bringing our first brand campaign and film to life.
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: e0b0ddbe-6960-48c2-a719-ff05b05c9a90 -->
+
+---
+
+## Post 16 — max_cosine = 0.274
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.274)
+- `Evaluating a martech partner` (cosine 0.223)
+- `Need to unify our customer data` (cosine 0.199)
+
+**Content:**
+
+```
+In another news, we have made it to The Wall Street Journal
+
+They reached out recently and I had an incredible half an hour to talk about RL Envs / Data and how the frontier is shaping up.
+
+Def, first of many.
+
+Article: https://trib.al/Af2ZYdx
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: b05e0134-4c22-4d10-b8af-3036ba7eb7c1 -->
+
+---
+
+## Post 17 — max_cosine = 0.266
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.266)
+- `Evaluating a martech partner` (cosine 0.261)
+- `Scaling performance marketing efficiently` (cosine 0.216)
+
+**Content:**
+
+```
+“Koi challenge bada nahi hota?”
+
+My dessert came with a fortune cookie.
+Inside it said: “No challenge is too big for you.”
+
+Founders love lines like this.
+They sound like fuel.
+
+But in startups, challenges are not beaten by belief.
+They’re beaten by leverage.
+
+Markets don’t care how badly you want it.
+Distribution doesn’t reward effort.
+Capital doesn’t move for confidence.
+
+Big challenges fall to:
+- unfair access,
+- timing that looks like luck,
+- compounding that nobody sees yet,
+- and systems that keep working while you sleep.
+
+Not motivation.
+
+These quotes survive because they make failure feel personal.
+If you didn’t make it, you just didn’t want it enough.
+
+That’s comforting.
+And completely wrong.
+
+Most startup challenges are big for a reason.
+They’re meant to break most people.
+That’s the filter.
+
+The cookie didn’t lie.
+It just made the grind sound kinder than it is.
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 4c10e990-bed1-403f-826e-ddc84b3e7047 -->
+
+---
+
+## Post 18 — max_cosine = 0.261
+
+**Top-3 matching signals:**
+- `Evaluating a martech partner` (cosine 0.261)
+- `Modernizing our digital growth engine` (cosine 0.247)
+- `Need better lifecycle personalization` (cosine 0.236)
+
+**Content:**
+
+```
+Meet Shashank Mehta, founder of The Whole Truth and a Loopiehead.
+He trusted us with the car seat.
+
+Shashank as we all know is a really honest person. Like his own genuine self, he told me once "Akriti, most days I am a half decent founder and a half decent father. Trying to do better both places daily" :).
+That is him, and also so many other fathers in this modern world. Navigating their careers, their fitness goals and setting higher than ever standards of fatherhood <3. I love this world, I am immensely lucky to be building Loopie now.
+
+"Meet the Loopieheads" is my favorite campaign that we have done so far.
+Loopie completed 1 year this April and the best way to complete the year was to understand the world of our beloved Loopieheads.
+To understand how has parenting been for them so far.
+To talk to them and understand what really is modern parenting.
+And bring out a summary of their thoughts and put it out in the world.
+
+Watch this wholesome episode.
+Also stay tuned for a lot more.
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 0bf6d256-2b6c-478d-a840-ad4a311f94ef -->
+
+---
+
+## Post 19 — max_cosine = 0.250
+
+**Top-3 matching signals:**
+- `Need better lifecycle personalization` (cosine 0.250)
+- `Evaluating a martech partner` (cosine 0.245)
+- `Scaling performance marketing efficiently` (cosine 0.207)
+
+**Content:**
+
+```
+HR during appraisal 👇🏻
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 24c785cb-79e0-4496-9525-f366abc72274 -->
+
+---
+
+## Post 20 — max_cosine = 0.245
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.245)
+- `Need better lifecycle personalization` (cosine 0.231)
+- `Need to unify our customer data` (cosine 0.211)
+
+**Content:**
+
+```
+Experience unparalleled! ✨
+
+Lumiere™ by RBL Bank #InspiredByYou
+
+#ApnoKaBank #RBLBank
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: ff0d0f92-d6b7-4c05-99e0-9772999a8958 -->
+
+---
+
+## Post 21 — max_cosine = 0.245
+
+**Top-3 matching signals:**
+- `Scaling performance marketing efficiently` (cosine 0.245)
+- `Evaluating a martech partner` (cosine 0.239)
+- `Need better lifecycle personalization` (cosine 0.236)
+
+**Content:**
+
+```
+“Aadat lagane ka sabse acha tareeka? Free mein de do.”
+
+My Zepto order came with a free Red Bull.
+No offer. No explanation. It was just there.
+
+That wasn’t generosity.
+It was distribution.
+
+The post-delivery moment is predictable. Task done. Mood neutral. Resistance low.
+That is where behaviour gets inserted.
+
+This wasn’t advertising.
+It was habit placement.
+
+Ads try to persuade.
+Freebies skip persuasion and move straight into routine.
+
+Red Bull didn’t need messaging. Zepto handled timing and placement.
+The rest is chemistry.
+
+Nothing about this was accidental.
+It was designed.
+
+Free koi favour nahi hota.
+Bas brand quietly bolta hai: “ab(use) kar.”
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 5e2ce31d-e138-4ff8-84ce-dadd6f79eb0d -->
+
+---
+
+## Post 22 — max_cosine = 0.242
+
+**Top-3 matching signals:**
+- `Scaling performance marketing efficiently` (cosine 0.242)
+- `Fixing analytics governance` (cosine 0.226)
+- `Evaluating a martech partner` (cosine 0.223)
+
+**Content:**
+
+```
+You can't miss this! Super engaging and insightful.
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 3d8dcf46-6548-4751-b69d-5fed2c7e5c72 -->
+
+---
+
+## Post 23 — max_cosine = 0.240
+
+**Top-3 matching signals:**
+- `Need better lifecycle personalization` (cosine 0.240)
+- `Modernizing our digital growth engine` (cosine 0.209)
+- `Evaluating a martech partner` (cosine 0.188)
+
+**Content:**
+
+```
+My biggest financial decision in my 20s wasn’t an investment in Stocks or a Mutual Fund!
+
+It was buying my own house. Exactly 4 years ago, today I bought a Flat and to many it didn’t feel like a “smart” move. Ofcourse, Liquidity took a hit and EMIs kicked in. But I still went ahead.
+
+Here’s what I’ve learnt since:
+
+1) Clarity beats optionality - Owning a house forced discipline. Less impulsive spending, more structured financial thinking.
+
+2) Peace has a return, even if it’s not in Excel - There’s a different kind of stability that comes with knowing you have your own space. Hard to quantify, but very real.
+
+3) It changes how you take risks - Ironically, having a fixed responsibility made me sharper about career and financial decisions and not more fearful.
+
+4) Real estate is not just a financial decision - It’s emotional, psychological, and lifestyle-driven. Treating it purely as ROI is incomplete.
+
+Would I do it again?
+
+Yes. But with even more awareness of the trade-offs.
+
+Most people debate “rent vs buy” like it’s a formula.
+
+But in my opinion, it's not. It’s a personal decision shaped by your priorities, risk appetite, and stage of life. Sharing a glimpse of my happy place 😊❤️
+
+Curious to know what’s been your biggest financial decision so far?
+
+#PersonalFinance #RealEstate #Investment
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 9ef65328-9133-4979-bd53-5770262916f1 -->
+
+---
+
+## Post 24 — max_cosine = 0.237
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.237)
+- `Evaluating a martech partner` (cosine 0.221)
+- `Need better lifecycle personalization` (cosine 0.214)
+
+**Content:**
+
+```
+Brave Parenting creates Brave Kids and Brave Kids are the ones who will change the World.
+
+Watched this gem, and found it to summarize parenting in such a beautiful way.
+Us, modern parents, are trying our best to keep our children safe in this messy world which is full of uncertainty. Our newer lifestyles have lesser people, we have created our own village with our friends, some family, help and so on. And its so hard to be brave.
+
+But its also necessary. The good news is we can be brave in all small big daily moments. My toddler is struggling with her 4 piece puzzle and I do not intervene, she is trying to lift the bucket filled with water and I do not intervene, she has fallen down and I am waiting for her to tell me if she needs support and so on. It is hard to see your child struggle and wait. Not doing anything, trusting their caliber and being confident of their judgement. These are things on me, what about her, she is figuring it out daily :)
+
+Adding the link here:
+https://lnkd.in/g7Vgpkky
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: c948fbb0-6706-4dc2-950d-05a5054c139c -->
+
+---
+
+## Post 25 — max_cosine = 0.236
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.236)
+- `Evaluating a martech partner` (cosine 0.203)
+- `Need to unify our customer data` (cosine 0.196)
+
+**Content:**
+
+```
+Tagging SpiceJet Limited because this needs to be said openly.
+
+Is this an airline or a running joke?
+
+I am here at the Airport waiting for you to finalize the take-off time and boarding gate. Here’s what passengers like me are dealing with:
+
+1) Relentless delays
+Flight rescheduled not once, not twice, but thrice from 22:35 → 23:35 → 00:10 → finally 00:40. This is not a delay, this is operational failure.
+
+2) Check-in chaos
+Your check-in counters were operating on what looked like a manual list. Boarding passes issued as tiny sticker slips. Is this 2026 or 1996?
+
+3) Sub-standard refreshments
+When you delay passengers repeatedly, the least expected is decent refreshments. What was served was frankly unacceptable.
+
+4) Incorrect display systems
+Even your airport display screens showed random timings like 23:40 which is completely disconnected from reality. Basic integration missing!
+
+This isn’t about one bad experience. This reflects a deeper issue: lack of systems, lack of accountability, and lack of respect for passengers’ time and trust.
+
+The real question to you is that are you actually capable of running an airline at scale, or are customers expected to tolerate this as normal?
+
+Passengers don’t expect perfection. But they do expect professionalism, reliability, and basic competence.
+
+Right now, none of that is visible. Its not been 6 months and this is 2nd new experience you unlocked for me.
+
+I am not sure if DGCA India has any quality standards for the players!
+
+#SpiceJet #AirlineExperience #CustomerExperience
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 33a8acd9-bbf7-4104-97a2-cd02bc60b3d1 -->
+
+---
+
+## Post 26 — max_cosine = 0.212
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.212)
+- `Evaluating a martech partner` (cosine 0.167)
+- `Need better lifecycle personalization` (cosine 0.152)
+
+**Content:**
+
+```
+Had a great shoot today with the legend Sunil Chhetri.
+
+What stands out most is not just his achievements, but his humility, discipline, and relentless commitment to excellence — truly inspiring.
+
+Something exciting is coming soon… stay tuned!
+
+#UtkarshSFB #RisingTogether #SunilChhetri  #Leadership #Inspiration #BankingWithPurpose #Trust #GrowthJourney #ComingSoon
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: a48e489b-dd56-488a-81c2-3670e551ce1a -->
+
+---
+
+## Post 27 — max_cosine = 0.201
+
+**Top-3 matching signals:**
+- `Modernizing our digital growth engine` (cosine 0.201)
+- `Need better lifecycle personalization` (cosine 0.180)
+- `Rebuilding our marketing automation stack` (cosine 0.176)
+
+**Content:**
+
+```
+We love being Loopie, I am a Loopiehead.
+While within the team we know the what it feels like, we have been trying to find way to convey this to others for a long time.
+
+Being Loopie is being yourself fully, your crazy happy self.
+This does not stop just because now you are a parent. It actually triples the fun.
+Now the whole family can be loopie together :)
+
+And finally we were able to convey this with Pune's first Baby Rave Party.
+I could see Mums dancing their hearts out.
+Dads making tired kids sleep or making them eat.
+Dads and Mums interchanging roles.
+Dads, Mums and kids all dancing, laughing together.
+
+All of this on baby tunes "Wheels on the bus go round and round, round and round, round and round...."
+<You know what I mean>
+
+And it was a full of fun, living in the moment Loopie Day!!
+And now with the first success, we already have Loopieheads from across the country tell us to do it there too.
+2026 just got way more exciting!
+
+Huge shoutout to Rini Goel, Kavish Sharma, Broadway, Chicken Masala Band and all others Loopieheads on this beautiful memory.
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 497b03e4-9ea5-445a-9017-610e5ddef7de -->
+
+---
+
+## Post 28 — max_cosine = 0.198
+
+**Top-3 matching signals:**
+- `Fixing analytics governance` (cosine 0.198)
+- `Rebuilding our marketing automation stack` (cosine 0.190)
+- `Modernizing our digital growth engine` (cosine 0.172)
+
+**Content:**
+
+```
+alphas and only alphas!
+
+groundzeroai.in/podcasts
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: 7ab3720f-1715-40f2-bf5a-6b5ee94c7123 -->
+
+---
+
+## Post 29 — max_cosine = 0.180
+
+**Top-3 matching signals:**
+- `Need to unify our customer data` (cosine 0.180)
+- `Modernizing our digital growth engine` (cosine 0.171)
+- `Scaling performance marketing efficiently` (cosine 0.130)
+
+**Content:**
+
+```
+Yeh sirf cricket nahi… yeh connection hai.
+Sheher se sheher, dil se dil—
+Utkarsh Small Finance Bank x Mumbai Indians
+
+#utkarshsfb #mumbaiindians #cricket
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: e0aa4de5-b44c-4e2e-80f4-92f6ca496585 -->
+
+---
+
+## Post 30 — max_cosine = 0.161
+
+**Top-3 matching signals:**
+- `Need to unify our customer data` (cosine 0.161)
+- `Fixing analytics governance` (cosine 0.146)
+- `Modernizing our digital growth engine` (cosine 0.144)
+
+**Content:**
+
+```
+Monday will feel better now 😌
+
+
+India India 🇮🇳
+```
+
+**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+
+**Reason (optional):**
+
+<!-- label-id: f877f801-d7d9-40de-97b1-a394e0055ef9 -->
+
+---

--- a/eval/calibration/dogfood-martech-agency.md
+++ b/eval/calibration/dogfood-martech-agency.md
@@ -220,7 +220,7 @@ In my view, AI has reduced effort and improved Time to Market. AI will do the li
 PS: AI hasn’t been recruited to write this. I haven’t outsourced my critical thinking, logical deduction or writing yet.
 ```
 
-**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+**Label:** `[x]`  ← replace with `[x]` if this is a real intent signal
 
 **Reason (optional):**
 
@@ -638,7 +638,7 @@ Welcoming Parineeti Chopra as OZi’s brand ambassador felt like a natural step 
 Proud of the team for bringing our first brand campaign and film to life.
 ```
 
-**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+**Label:** `[x]`  ← replace with `[x]` if this is a real intent signal
 
 **Reason (optional):**
 
@@ -754,7 +754,7 @@ Watch this wholesome episode.
 Also stay tuned for a lot more.
 ```
 
-**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+**Label:** `[x]`  ← replace with `[x]` if this is a real intent signal
 
 **Reason (optional):**
 
@@ -1057,7 +1057,7 @@ And now with the first success, we already have Loopieheads from across the coun
 Huge shoutout to Rini Goel, Kavish Sharma, Broadway, Chicken Masala Band and all others Loopieheads on this beautiful memory.
 ```
 
-**Label:** `[ ]`  ← replace with `[x]` if this is a real intent signal
+**Label:** `[x]`  ← replace with `[x]` if this is a real intent signal
 
 **Reason (optional):**
 

--- a/eval/calibration/findings-dogfood-martech.md
+++ b/eval/calibration/findings-dogfood-martech.md
@@ -1,0 +1,111 @@
+# Calibration Findings — Dogfood Workspace (Martech Agency Profile)
+
+**Workspace:** `eb23b44f-88ea-4a94-88ae-b9aca2d66345`
+**Dataset:** 30 posts with embeddings × 10 enabled signals = 300 pairs
+**Labeled:** all 30 posts, single-label under Philosophy A (post-level intent)
+**Date:** 2026-04-20
+**Labeler:** Sharad Chandel (Dwao agency owner, product owner)
+
+## TL;DR
+
+The current post-only Ring 2 matching model **cannot produce a usable alert product in this data**. The cosine distributions of "real intent signals" and "noise" are not just overlapping — they are **inverted**: the highest-cosine post across all 300 pairs was a non-match (vendor promoting a competing tool), while the four actual intent signals are spread across cosine 0.20–0.42, below multiple noise posts. No threshold on the existing single-axis score can recover usable precision and recall simultaneously.
+
+**F1_max = 0.27, F0.5_max = 0.25** — nearly random ranking for alert purposes.
+
+This is not a threshold-tuning problem. This is an architecture problem. The product requires **Phase 2.6 — Fit × Intent hybrid scoring** before any further calibration work is meaningful.
+
+## Labels
+
+Distribution: **4 yes / 26 no** out of 30.
+
+| # | Author (role) | Label | Notes |
+|---|---|---|---|
+| 4 | Akhilendra Pandey (AVP Product Marketing, RBL Bank) | y | Thoughtful personal essay on AI + marketing stack. Real decision-maker actively rethinking tools. |
+| 15 | Amit Sah (Founder, OZi) | y | Brand-ambassador campaign launch — founder actively investing in marketing. |
+| 18 | Akriti Gupta (Founder, Loopie) | y | "Meet the Loopieheads" 1-year brand campaign. Same pattern as 15. |
+| 27 | Akriti Gupta | y | "Pune's first Baby Rave Party" — active brand experiential marketing by same founder. |
+| rest | (various) | n | See doc for per-post notes. |
+
+## Cosine distribution
+
+| Group | n | min | p25 | median | p75 | max |
+|---|---|---|---|---|---|---|
+| matches | 4 | 0.201 | 0.261 | 0.279 | 0.424 | 0.424 |
+| non-matches | 26 | 0.161 | 0.240 | 0.301 | 0.354 | **0.475** |
+
+**Observation:** `max(non-matches)` > `max(matches)`. The distribution is not merely overlapping — it is inverted at the top end.
+
+**The highest-cosine post (0.475)** was labeled **no**: Lipi Mittal (CPO at NotifyVisitors, visible via "Powering 1000+ Global D2C Brands") posting an Acer cart-abandonment case study. The current model ranked this as most relevant. The labeler recognized it as a competing vendor, not a buyer.
+
+## Threshold sweep
+
+| Threshold | TP | FP | FN | TN | Precision | Recall | F1 | F0.5 | Verdict |
+|---|---|---|---|---|---|---|---|---|---|
+| 0.00 | 4 | 26 | 0 | 0 | 13% | 100% | 0.24 | 0.16 | fire on everything |
+| 0.20 | 4 | 23 | 0 | 3 | 15% | 100% | 0.26 | 0.18 | catches all real matches + 23 false alarms |
+| **0.25** | 3 | 15 | 1 | 11 | 17% | 75% | **0.27** | 0.20 | **max F1** |
+| 0.30 | 1 | 13 | 3 | 13 | 7% | 25% | 0.11 | 0.08 | worse |
+| 0.40 | 1 | 4 | 3 | 22 | 20% | 25% | 0.22 | 0.21 | — |
+| **0.41** | 1 | 3 | 3 | 23 | 25% | 25% | 0.25 | **0.25** | **max F0.5** |
+| 0.45 | 0 | 2 | 4 | 24 | 0% | 0% | 0.00 | 0.00 | misses everything |
+| **0.72** (current prod default) | 0 | 0 | 4 | 26 | n/a | 0% | 0.00 | 0.00 | **current behavior: silent** |
+
+**F1 max = 0.27** means for every real match surfaced, ~2.7 false positives fire.
+**F0.5 max = 0.25** means for every real match, 3 false positives fire AND 75% of real matches are missed.
+
+For comparison, commodity sales-intelligence products like Clay, Apollo, Clearbit ship with F1 ≥ 0.6 on their core match primitive. Sonar's current primitive is at **less than half** of that floor.
+
+## Why the model can't recover with better labels or more data
+
+Two structural problems stack:
+
+### 1. Asymmetry ceiling
+Signal phrases are short (5–7 words) aspirational B2B statements: *"Evaluating a martech partner"*, *"Rebuilding our marketing automation stack"*. LinkedIn posts are long (100+ words) personal/promotional narratives with emojis, case studies, cricket references.
+
+`text-embedding-3-small` encodes both into the same 1536-dim space. Cosine similarity reflects both semantic overlap *and* stylistic similarity. The stylistic gap alone depresses scores by 0.10–0.20 below what symmetric-retrieval benchmarks would suggest.
+
+Observed ceiling: 0.475 even on clearly-related case-study ↔ automation-stack pairs. This bounds the entire discriminative range of the signal.
+
+### 2. Missing author context ("the Divya dilemma")
+Posts where `post_content` is nearly irrelevant but `author` is a high-fit ICP lead:
+
+- **Post 7, 26, 29** — Divya Prakash Singhal, Brand/Marketing/AI Strategy at Utkarsh Bank. Three brand-copy amplifications; the current model correctly gives them low scores, but the labeler recognizes she is squarely in the martech agency's ICP. Three wasted opportunities per labeling round. At scale: thousands of missed conversations per month.
+- **Post 20, 22** — Akhilendra Pandey, AVP Product Marketing at RBL Bank. Same author produced **Post 4** (a strong buying-intent essay labeled yes) and **Posts 20, 22** (thin brand-copy noise labeled no). The model has no way to use Post 4's signal to weight Akhilendra's future posts.
+
+Posts where `post_content` scores highly but `author` is off-ICP:
+
+- **Post 1, Post 2** — Lipi Mittal, NotifyVisitors CPO. The model ranks the two highest-cosine posts in the entire dataset. Both are the ICP's *competitor* amplifying their own tool. Firing on these would burn trust faster than any other failure mode.
+- **Post 11** — Gaurav Taparia, Director of Sales at MoEngage. Competing vendor (the specific vendor the owner considered re-dogfooding against).
+
+The common thread: cosine of text-content-only cannot see any of this. It sees words, not people.
+
+## Implications for the roadmap
+
+Per `CLAUDE.md`:
+
+- **Phase 2 status:** 4 of 5 slices shipped. Final slice was supposed to be **Discovery** (Ring 3 nightly HDBSCAN clustering for emerging topics + weekly digest).
+- **Finding:** Discovery clusters posts *by the same signal* the calibration just proved inadequate. Clusters built on a signal with F1=0.27 will group noise, not trends. Discovery on top of this is building on sand.
+- **Phase 3 was originally sketched** as *real-time alerts, CRM integrations, team features*. Those are expansion features that all depend on matches being meaningful.
+
+### Recommended resequence
+
+1. **Phase 2.5** (new) — **File all calibration evidence** + document the gap. Produced by this exercise.
+2. **Phase 2.6** (new) — **Fit × Intent scoring redesign.** Required before Discovery can produce useful clusters.
+   - Fit score: per-connection, derived from headline + company + role vs. workspace ICP profile. Asymmetric retrieval model (BGE, E5, or OpenAI `text-embedding-3-large` with asymmetric prompts) as a candidate for the fit encoder.
+   - Intent score: per-post, refined from current Ring 2 with signal expansion (augment short phrases with example-post longer text) to lift the asymmetry ceiling.
+   - Combined: multiplicative (standard Fit × Intent, matches 6sense / Apollo / Demandbase pattern).
+   - Recalibrate both independently against a new labeling pass.
+3. **Phase 2 Discovery** — delay until 2.6 ships. Clustering needs a useful signal.
+4. **Phase 3 expansion** features — deprioritize versus 2.6.
+
+### What NOT to do
+
+- **Do not ship the product with the current matching primitive and hope users tune it.** Threshold 0.72 currently fires on nothing. Any threshold that fires on real matches also fires on majority-false-positive noise. Users will churn inside one week.
+- **Do not build user-facing feedback-loop training** on top of this primitive yet. The `feedback_trainer` adaptive logic assumes the primitive can discriminate given a good starting point; it cannot.
+- **Do not invest in more signal engineering (better signal phrases, more signals per workspace) as a fix.** The asymmetry ceiling caps even perfect signals at ~0.5 cosine.
+
+## Artifacts
+
+- `eval/calibration/dogfood-martech-agency.md` — the labeled dataset (30 posts, 4 yes, 26 no)
+- `eval/calibration/phase-2.6-evidence.md` — the specific ICP-mismatch examples called out during labeling
+- `backend/scripts/calibrate_matching.py` — reusable harness; export and analyze phases. Point it at any workspace, any labeling file. Will be re-run against Phase 2.6 once the hybrid scorer lands.

--- a/eval/calibration/phase-2.6-evidence.md
+++ b/eval/calibration/phase-2.6-evidence.md
@@ -1,0 +1,99 @@
+# Phase 2.6 Evidence Pool
+
+Concrete cases from the session-8 labeling pass that illustrate why **post-only Ring 2 cosine similarity cannot distinguish buying intent from noise in a real user network.** These cases ground the Phase 2.6 (Fit × Intent) design discussion — they are real posts, real authors, real (non-)matches.
+
+Every case is from the dogfood workspace `eb23b44f-88ea-4a94-88ae-b9aca2d66345`. Author details are labeler-visible information only (LinkedIn headlines), nothing scraped or private.
+
+---
+
+## Category A — Author is strong ICP, but the post content is thin / brand-copy
+
+These are *misses* of the current model: labeler marked **n** under strict post-level, but the author is exactly the person a martech agency would want to be alerted about.
+
+### A1. Divya Prakash Singhal — Utkarsh Small Finance Bank
+
+**Headline:** "Brand, Marketing & AI Strategy | Building Scalable Growth Engines in BFSI"
+
+Three posts in the dataset:
+- **Post 7** — "Experience unparalleled! ✨ Lumiere™ by RBL Bank #InspiredByYou". One-line brand promo. Labeled **n**.
+- **Post 26** — "Had a great shoot today with the legend Sunil Chhetri. … Something exciting is coming soon… stay tuned! #UtkarshSFB". Teaser. Labeled **n**.
+- **Post 29** — "Yeh sirf cricket nahi… yeh connection hai. Utkarsh Small Finance Bank x Mumbai Indians". Brand cricket-sponsorship promo. Labeled **n**.
+
+**Why this matters:** Divya's headline is nearly a textbook martech-agency ICP — brand + marketing + AI strategy leader in a regulated, growth-motivated vertical (BFSI). The three posts are her doing her job (amplifying brand work). The current model correctly gives each low cosine, but the model has no way to see the author context that would flag her as a person worth reaching out to *at all times*, independent of post content.
+
+In a hybrid model: high fit × low intent per post = low-priority persistent nurture, not silent drop.
+
+### A2. Akhilendra Pandey — RBL Bank
+
+**Headline:** "AVP - Product Marketing, RBL Bank | Symbiosis Institute of International Business"
+
+Three posts in the dataset:
+- **Post 4** — Long personal essay on AI + product marketing + stack consolidation. Thoughtful, explicit about rethinking tools. **Labeled y.** cosine 0.424.
+- **Post 20** — "Experience unparalleled! ✨ Lumiere™ by RBL Bank". One-liner. Labeled **n**. cosine 0.245.
+- **Post 22** — "You can't miss this! Super engaging and insightful." Thin amplification. Labeled **n**. cosine 0.242.
+
+**Why this matters:** Same author, three posts. One is a real buying-intent signal; two are brand-copy noise. The current model scores them roughly proportionally but treats each post independently — **no memory that this author already demonstrated high intent on a prior post.** In a hybrid model: Post 4 establishes a high fit score for Akhilendra; Posts 20 and 22 ride that fit score upward because they come from the same verified-ICP author.
+
+---
+
+## Category B — Post content is highly relevant, but the author is anti-ICP
+
+These are *false positives* of the current model: the top cosines in the entire 300-pair dataset, all correctly labeled **n** by the labeler for reasons the current model cannot see.
+
+### B1. Lipi Mittal — NotifyVisitors (martech vendor)
+
+**Headline:** "5x 🚀 AI Driven Ecom Growth | CPO | 2x Revenue & Conversion, 3x MAU, 2x Orders | **Powering 1000+ Global D2C Brands** | Driving Retention & Data-Led Personalization"
+
+Two posts in the dataset, ranked **#1 and #2 by cosine** across all 300 pairs:
+- **Post 1** — NotifyVisitors Acer cart-abandonment case study. **Cosine 0.475 (highest in the entire dataset).** Labeled **n**.
+- **Post 2** — NotifyVisitors Just Herbs engagement case study. **Cosine 0.470.** Labeled **n**.
+
+**Why this matters:** Lipi's "Powering 1000+ Global D2C Brands" language is vendor-speak: she works AT a martech SaaS. Her posts are the company's marketing content. The martech agency labeling is the correct answer — she is a competitor, not a buyer. **If the product shipped today, these two posts would be the first two alerts the user sees**, and they are the worst possible alerts: "your competitor posted about their wins." Not just a missed opportunity — an actively trust-burning alert.
+
+### B2. Gaurav Taparia — MoEngage (martech vendor)
+
+**Headline:** "Director Sales at MoEngage | Ex-IBM, HP"
+
+One post in the dataset:
+- **Post 11** — "Glad to share that I made it to the President's Club at MoEngage for the 4th year in a row!" Career milestone at a competing vendor. Labeled **n**. cosine 0.335.
+
+**Why this matters:** Gaurav is a senior sales person at *the exact martech product* (MoEngage) the user considered as a positioning alternative during the session. His LinkedIn activity will skew heavily toward martech content for obvious reasons — he sells it for a living. Under hybrid scoring: **fit ≈ 0** (he is a vendor selling a competing product) **× intent > 0** = filtered out regardless of content cosine.
+
+---
+
+## Category C — Author is a buyer-ICP founder actively investing in marketing
+
+These are *correct positives* that the current model surfaces weakly or not at all because the cosine on brand-campaign posts is moderate, not high.
+
+### C1. Amit Sah — OZi (modern parenting brand founder)
+
+- **Post 15** — "Welcoming Parineeti Chopra as OZi's brand ambassador". Brand-ambassador campaign launch. **Labeled y.** cosine 0.279.
+
+**Why this matters:** A founder announcing their first brand ambassador is investing real money in marketing. Martech agency alarm should ring here. Current model: cosine 0.279 puts this below the workspace's own threshold of 0.30; the product would go silent on exactly the moment the customer becomes alert-worthy.
+
+### C2. Akriti Gupta — Loopie (modern parenting brand founder)
+
+- **Post 18** — "Meet the Loopieheads" 1-year brand campaign. **Labeled y.** cosine 0.261.
+- **Post 27** — "Pune's first Baby Rave Party — Loopie brand activation". **Labeled y.** cosine 0.228.
+
+**Why this matters:** Same founder, actively running *multiple* brand marketing investments in parallel. Two posts labeled y; both below cosine 0.3. Same silent failure as C1.
+
+---
+
+## Implications for Phase 2.6 design
+
+The six cases above cover the two failure modes the hybrid Fit × Intent scoring must fix:
+
+1. **Fit lookup must persist and influence per-post scoring even when post content is thin** (Category A).
+2. **Fit lookup must down-rank posts from ICP-opposites** (competitors, vendors selling the same thing as the user) (Category B).
+3. **Fit boost must lift "brand-investing buyer" posts above the dominated intent-only ranking** (Category C).
+
+Concrete Phase 2.6 requirements the evidence justifies:
+
+- **Per-connection fit_score** derived from headline + company + role, stored on the connection (not computed per-post). Refreshes when headline changes.
+- **fit_score inputs:** positive examples (labeler's target ICP description), negative examples (competitors, vendors selling same category). Matches the industry standard of "ICP fit with disqualifier rules."
+- **Combined score:** multiplicative. `final_score = fit_score × intent_score`. Fit ≈ 0 (a vendor) × any intent = near-zero.
+- **Persistence of prior-post evidence:** if an author has produced one strong intent post, subsequent posts from the same author should get a fit-score bump. (Think of it as a Bayesian prior update.)
+- **Threshold calibration AFTER the architecture lands** — not before. This calibration run is the "before" baseline; the next calibration run will be the "after."
+
+The specific encoder / prompting / model choices for the fit model are open questions worth a dedicated design session. The product requirement is settled by the evidence above.


### PR DESCRIPTION
Closes #106 (superseded by #113 — see below).
Linked: #113.

## What this PR is

Two deliverables:

1. **`backend/scripts/calibrate_matching.py`** — reusable two-phase calibration harness. Exports a labeling markdown doc from any workspace's posts + signals; ingests user-provided binary labels; runs a full threshold sweep (step 0.01) with precision/recall/F1/F0.5 at every step.
2. **The first real labeling pass** against the dogfood martech-agency workspace — 30 posts labeled by the product owner, full findings report, evidence pool for Phase 2.6.

## The headline finding

**The current post-only Ring 2 matching model cannot discriminate buying intent from noise in this data.** F1_max = 0.27. The highest-cosine post in the entire dataset was correctly labeled a non-match (competing vendor's promotional content). Distributions of real-match vs non-match cosines are *inverted* at the top, not just overlapping.

This is not a threshold-tuning problem. The architecture needs **Phase 2.6 — Fit × Intent hybrid scoring** before any further calibration work is meaningful.

Full analysis in `eval/calibration/findings-dogfood-martech.md`. Concrete evidence cases in `eval/calibration/phase-2.6-evidence.md`. Product-decision write-up in issue #113.

## Files

- `backend/scripts/calibrate_matching.py` — harness (export + analyze subcommands)
- `eval/calibration/dogfood-martech-agency.md` — labeled dataset (30 posts, 4 yes, 26 no)
- `eval/calibration/findings-dogfood-martech.md` — full findings report with threshold sweep, root-cause analysis, roadmap implications
- `eval/calibration/phase-2.6-evidence.md` — six concrete cases illustrating the Fit × Intent gaps

## Why this is a merge-worthy PR even though no product code changed

- The harness is permanent infrastructure — it will be re-run against every future workspace, and against Phase 2.6 as the \"after\" baseline.
- The labeled dataset is the eval set for Phase 2.6. We will use it to measure whether the hybrid scorer actually fixes the gap. Without this committed, we have no ground truth to calibrate against later.
- The findings + evidence docs are linked from issue #113 and will be referenced in the Phase 2.6 design doc.

## Test plan

- [x] Harness export phase generates 30-post labeling doc correctly
- [x] Harness analyze phase parses the filled-in labels, runs sweep, reports F1/F0.5
- [x] Backend tests: full suite still passes (calibrate_matching.py is standalone, doesn't import from production pipeline)
- [x] No production code changes — no risk to live matching/scoring behavior

## Follow-ups (not in this PR)

- Issue #113 — Phase 2.6 Fit × Intent scoring redesign
- Issue #106 (\"threshold calibration\") — superseded by #113 and can be closed with a cross-link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a calibration workflow tool with export and analysis modes to empirically determine optimal matching thresholds per workspace.

* **Documentation**
  * Added calibration reports and evidence documentation detailing threshold optimization findings and model improvement roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->