### PR TITLE
feat: Phase 2.6 — Fit × Intent hybrid scoring (Tasks 1–8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ htmlcov/
 # should never be committed).
 celerybeat-schedule
 
+# DB snapshots (pg_dump output taken before multi-migration phases for
+# local recovery). May contain PII; local safety only. See CLAUDE.md
+# "Snapshot the dogfood DB before any multi-migration phase."
+snapshots/
+
 # Node / Extension
 node_modules/
 dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,14 @@ Every Phase 2+ contribution aims to meet these. When skipping something, call it
 - **Never add `NOT NULL` without a default** — it locks large tables and takes production down.
 - **pgvector embedding columns in BOTH the migration and the ORM** — use `pgvector.sqlalchemy.Vector(1536)` in the ORM so `Base.metadata.create_all` builds it for tests.
 - **Don't bundle Phase 1 gap fixes into Phase 2 migrations without an explicit comment** explaining what you're fixing and why.
+- **NEVER run `alembic downgrade base` (or any `alembic downgrade` below `head`) against the `sonar` dev DB.** It runs `DROP TABLE` on every table and wipes all rows. For migration round-trip tests, override `sqlalchemy.url` inside the test fixture to point at `sonar_test` — see `backend/tests/test_migration_008_009_010.py::alembic_cfg` for the canonical pattern. Never embed `alembic downgrade` as a shell-step "fresh start" in an implementation plan. Phase 2.6 Task 1 (2026-04-21) lost all session-8 dogfood data this way.
+- **Snapshot the dogfood DB before any multi-migration phase.** First command of any migration-touching session:
+  ```bash
+  mkdir -p snapshots/
+  docker compose exec -T postgres pg_dump -U sonar sonar > snapshots/$(date +%Y-%m-%d)-pre-<phase>.sql
+  ```
+  `snapshots/` is gitignored (dumps may carry PII). Local safety only. Without this, an accidental destructive command during plan execution has no recovery path.
+- **Codex review is mandatory for plans that touch migrations or shared DBs.** "Any plan that runs commands against shared DBs must be codex-reviewed" — time-saved by skipping is minutes; time-lost to an unrecovered wipe is hours-to-days. Phase 2.6's destructive step would have been caught by codex.
 
 ### Deployment and release
 - **Semver + git tags** on every release. No "main-only" implicit versions.

--- a/TODO.html
+++ b/TODO.html
@@ -455,63 +455,64 @@
   <!-- HERO: first action next session -->
   <section class="hero">
     <span class="pill info">Start here tomorrow</span>
-    <h3 style="margin-top:10px">✅ Review + merge PR #114 (calibration findings), then brainstorm Phase 2.6</h3>
-    <p>Read <code>eval/calibration/findings-dogfood-martech.md</code> and <code>phase-2.6-evidence.md</code> on PR #114. If the interpretation holds, merge. Close issue #106 as superseded by #113. Then start <code>superpowers:brainstorming</code> to scope the Fit × Intent scoring redesign — that's the only thing on the critical path now.</p>
+    <h3 style="margin-top:10px">🔬 Manual browser walkthrough of the 6-step wizard, then run Task 9 calibration</h3>
+    <p>Phase 2.6 code Tasks 1–8 are shipped in <a href="https://github.com/nischal94/sonar/pull/119">PR #119</a> (186 tests green, merge blocker <a href="https://github.com/nischal94/sonar/issues/120">#120</a> fixed). Only Task 9 (operational) remains. Walk the wizard in Chrome, then run <code>analyze-hybrid</code> for Dwao + CleverTap to pick the winning λ. Flip <code>use_hybrid_scoring=True</code> only if DoD passes on both (P@5 ≥ 0.6, Recall@5 ≥ 0.5, zero top-5 competitors).</p>
     <div class="hero-meta">
-      <span>After this: 🧭 Phase 2.6 design brainstorm → 🔒 #107 + #108 hardening → Phase 2.6 implementation → Discovery (deferred until 2.6 ships)</span>
+      <span>After this: 🎯 Task 9 calibration → 🚀 merge PR #119 + flip flag → 🛠 address follow-ups <a href="https://github.com/nischal94/sonar/issues/121">#121</a>–<a href="https://github.com/nischal94/sonar/issues/124">#124</a> → Discovery (deferred until 2.6 DoD passes)</span>
       <span>Full ordered plan with rationale in the Next Session Action Plan section below</span>
     </div>
   </section>
 
   <!-- NEXT SESSION ACTION PLAN — mirrors TODO.md §"Next Session Action Plan" -->
-  <h2>Next Session Action Plan <span style="font-size: 12px; color: var(--ink-soft); font-weight: normal;">(last rewritten 2026-04-20, end of session 8)</span></h2>
-  <p class="tight" style="color: var(--ink-soft); margin-bottom: 16px;">Ordered. Item 1 is literally the first thing to do. Each item has What / Why now / Blocks / Effort.</p>
+  <h2>Next Session Action Plan <span style="font-size: 12px; color: var(--ink-soft); font-weight: normal;">(last rewritten 2026-04-21, end of session 10)</span></h2>
+  <p class="tight" style="color: var(--ink-soft); margin-bottom: 16px;">Ordered. Item 1 is literally the first thing to do. Each item has What / Why now / Blocks / Effort. State at resume: branch <code>feat/phase-2-6-migrations</code> HEAD = <code>583154b</code>; 186 tests green; <a href="https://github.com/nischal94/sonar/pull/119">PR #119</a> open.</p>
 
   <div class="action-plan">
     <details open>
-      <summary><strong>1. ✅ Review + merge PR <a href="https://github.com/nischal94/sonar/pull/114">#114</a> (calibration findings)</strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">15–30 min &middot; do first</span></summary>
+      <summary><strong>1. 🔬 Manual browser walkthrough of the 6-step wizard</strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">10–15 min &middot; do first</span></summary>
       <ul style="margin:12px 0 4px; padding-left:20px; color: var(--ink-soft);">
-        <li><strong>What:</strong> Read <code>eval/calibration/findings-dogfood-martech.md</code> and <code>phase-2.6-evidence.md</code>. If the interpretation holds, merge. Close <a href="https://github.com/nischal94/sonar/issues/106">#106</a> as superseded by <a href="https://github.com/nischal94/sonar/issues/113">#113</a> with a cross-link.</li>
-        <li><strong>Why now:</strong> Calibration evidence is only on a feature branch. Every subsequent decision depends on it being canonical in <code>main</code>.</li>
-        <li><strong>Blocks:</strong> Item 2 (Phase 2.6 brainstorm should reference merged evidence, not a PR branch).</li>
-        <li><strong>Effort:</strong> 15–30 min.</li>
+        <li><strong>What:</strong> <code>docker compose up -d frontend &amp;&amp; open http://localhost:5173/signals/setup</code>. Walk all 6 steps: enter "What do you sell?" → <strong>new ICP review step 3</strong> appears showing extracted ICP + seller_mirror → edit each field → proceed to signal generation → accept/reject → save. Check devtools network tab for <code>/profile/extract</code> (returns icp + seller_mirror) and <code>/profile/update-icp</code> (fires only if edited). Screenshot for PR merge record.</li>
+        <li><strong>Why now:</strong> Per CLAUDE.md lessons learned, frontend changes require a human in the browser; <code>npm run build</code> proves the bundle compiles, not that React rendering works at runtime. Last gate before Task 9's calibration run.</li>
+        <li><strong>Blocks:</strong> Item 2 (calibration run needs a confirmed working ICP extraction flow) and item 3 (PR merge).</li>
+        <li><strong>Effort:</strong> 10–15 min.</li>
       </ul>
     </details>
 
     <details>
-      <summary><strong>2. 🧭 Phase 2.6 — Fit × Intent scoring design brainstorm</strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">full session &middot; the central session-9 activity</span></summary>
+      <summary><strong>2. 🎯 Task 9 — run Phase 2.6 calibration + decide flag flip</strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">1–2 hours &middot; ship/don't-ship gate</span></summary>
       <ul style="margin:12px 0 4px; padding-left:20px; color: var(--ink-soft);">
-        <li><strong>What:</strong> Run <code>superpowers:brainstorming</code> with problem framed per <a href="https://github.com/nischal94/sonar/issues/113">#113</a>. Produce <code>docs/phase-2-6/design.md</code> covering: fit-encoder choice (BGE / E5 / OpenAI 3-large with asymmetric prompts), per-connection <code>fit_score</code> schema + inputs (headline + company + role vs. ICP), ICP disqualifiers (competitors, vendors in same category), combination strategy (multiplicative vs additive), persistence-of-prior-signals (Bayesian bump across posts from high-intent authors), calibration plan (re-use <code>backend/scripts/calibrate_matching.py</code>, same 30-post dogfood dataset as before/after baseline).</li>
-        <li><strong>Why now:</strong> Single most important open question for the product. The calibration proved the current primitive cannot ship. Every other Phase 2 + Phase 3 item depends on matching being meaningful.</li>
-        <li><strong>Blocks:</strong> Phase 2 Discovery, all Phase 3 work, any launch plan.</li>
-        <li><strong>Effort:</strong> Full session brainstorming + design doc. Implementation is 2–3 sessions after.</li>
+        <li><strong>What:</strong> For both Dwao and CleverTap workspaces — extract ICP via <code>/profile/extract</code>, run <code>python scripts/backfill_fit_scores.py --workspace-id &lt;uuid&gt;</code>, then <code>python scripts/calibrate_matching.py analyze-hybrid --workspace-id &lt;uuid&gt; --labels eval/calibration/&lt;dataset&gt;.md --lambdas 0.0,0.1,0.2,0.3,0.5,0.7,1.0</code>. Re-label the 30-post dogfood dataset under the CleverTap lens first (~15 min). Pick the winning λ that satisfies DoD on BOTH workspaces: P@5 ≥ 0.6, Recall@5 ≥ 0.5, zero top-5 competitors. Document findings at <code>eval/calibration/phase-2-6-findings.md</code>.</li>
+        <li><strong>Why now:</strong> Ship/don't-ship gate. The implementation is shippable code; whether it improves matching is an empirical question only calibration answers. If DoD fails, see <code>design.md §5 step 8</code> for diagnostic paths.</li>
+        <li><strong>Blocks:</strong> flag flip on dogfood workspace. PR #119 can merge independently, but the flip is the operational goal.</li>
+        <li><strong>Effort:</strong> 1–2 hours (ICP extraction × 2 workspaces, backfill × 2, analyze-hybrid × 2, CleverTap re-label, findings writeup).</li>
       </ul>
     </details>
 
     <details>
-      <summary><strong>3. 🔒 Hardening: issues <a href="https://github.com/nischal94/sonar/issues/107">#107</a> + <a href="https://github.com/nischal94/sonar/issues/108">#108</a></strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">~1.5 hours combined &middot; do before first external user</span></summary>
+      <summary><strong>3. 🚀 Merge PR #119 + flip the flag for dogfood workspace</strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">5 min + 2 weeks monitoring</span></summary>
       <ul style="margin:12px 0 4px; padding-left:20px; color: var(--ink-soft);">
-        <li><strong>#107 — CORS service-worker routing:</strong> Route extension fetches through the background service worker (origin <code>chrome-extension://&lt;id&gt;</code>, already allowed). Remove <code>https://www.linkedin.com</code> from <code>app/main.py</code> <code>allow_origins</code>. Closes the <code>/auth/token</code> response-read exposure the session-7 CORS widening created. <strong>Effort:</strong> ~1 hour.</li>
-        <li><strong>#108 — Apify token to Authorization header:</strong> Move from URL query param (<code>?token=apify_api_...</code>) to <code>Authorization: Bearer</code> in <code>app/services/apify.py</code>. Verify harvestapi accepts header auth. Stops plaintext-token leak into worker logs. <strong>Effort:</strong> ~30 minutes.</li>
-        <li><strong>Why now:</strong> Both small, both security-adjacent. Best done before any external user signs up. Not blocked on Phase 2.6; can ship in parallel.</li>
+        <li><strong>What:</strong> After items 1 + 2 pass, merge <a href="https://github.com/nischal94/sonar/pull/119">PR #119</a>. Then <code>UPDATE workspaces SET use_hybrid_scoring = TRUE WHERE id = '&lt;Dwao_uuid&gt;';</code>. Monitor <code>/dashboard</code> output + delivered alerts for 1–2 weeks against the session-8 baseline.</li>
+        <li><strong>Why now:</strong> Phase 2.6 code is inert until the flag flips. Per-workspace rollout means rollback is a single SQL flip.</li>
+        <li><strong>Effort:</strong> 5 min merge + flip. 1–2 weeks monitoring.</li>
       </ul>
     </details>
 
     <details>
-      <summary><strong>4. 🛠 Small quality fixes</strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">any time, low effort</span></summary>
+      <summary><strong>4. 🛠 Address Phase 2.6 follow-up issues</strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">any time, low-to-medium effort</span></summary>
       <ul style="margin:12px 0 4px; padding-left:20px; color: var(--ink-soft);">
-        <li><strong><a href="https://github.com/nischal94/sonar/issues/110">#110</a> — Ring 1 dead:</strong> Signals are full phrases; Ring 1 does literal substring match; produces zero hits. May disappear if Phase 2.6 reshapes signal shape; revisit during 2.6 design.</li>
-        <li><strong><a href="https://github.com/nischal94/sonar/issues/111">#111</a> — Dashboard slider default 0.65 ignores workspace <code>matching_threshold</code>:</strong> ~30 min frontend fix. Not urgent.</li>
-        <li><strong>Dogfood DB cleanup:</strong> Session-8 ran the <code>UPDATE connections SET relationship_score = NULL WHERE relationship_score = 0.5 AND NOT has_interacted</code> from PR <a href="https://github.com/nischal94/sonar/pull/112">#112</a>. Noted here in case a fresh env is restored from snapshot.</li>
+        <li><strong><a href="https://github.com/nischal94/sonar/issues/121">#121</a> — PROMPT_VERSION logging:</strong> systemic tech debt; also affects the existing <code>extract_capability_profile</code>.</li>
+        <li><strong><a href="https://github.com/nischal94/sonar/issues/122">#122</a> — wizard per-field dirty flags:</strong> avoid redundant re-embed on unchanged field. UX polish.</li>
+        <li><strong><a href="https://github.com/nischal94/sonar/issues/123">#123</a> — pipeline fit_score race:</strong> idempotent outcome; low priority until traffic scales.</li>
+        <li><strong><a href="https://github.com/nischal94/sonar/issues/124">#124</a> — workspace.hybrid_lambda column:</strong> add only if Task 9 picks λ ≠ 0.3. Close as "no action needed" otherwise.</li>
+        <li><strong>Also deferred from session 8:</strong> <a href="https://github.com/nischal94/sonar/issues/107">#107</a> CORS service-worker routing, <a href="https://github.com/nischal94/sonar/issues/108">#108</a> Apify token → Authorization header, <a href="https://github.com/nischal94/sonar/issues/110">#110</a> Ring 1 dead, <a href="https://github.com/nischal94/sonar/issues/111">#111</a> dashboard slider default. None block Phase 2.6.</li>
       </ul>
     </details>
 
     <details>
-      <summary><strong>5. 🧭 Phase 2 Discovery</strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">DEFERRED until Phase 2.6 ships</span></summary>
+      <summary><strong>5. 🧭 Phase 2 Discovery</strong> &middot; <span style="color: var(--ink-soft); font-weight: normal;">DEFERRED until Phase 2.6 DoD passes</span></summary>
       <ul style="margin:12px 0 4px; padding-left:20px; color: var(--ink-soft);">
         <li><strong>What:</strong> Ring 3 nightly HDBSCAN clustering for emerging topics + Weekly Digest Email. Per <code>docs/phase-2/design.md §4.4</code>.</li>
-        <li><strong>Why not now:</strong> Clustering the current matching signal clusters noise (F1 = 0.27). Discovery is building on sand until 2.6 lands.</li>
-        <li><strong>When to revisit:</strong> After Phase 2.6 ships <em>and</em> re-calibration produces F1 ≥ 0.6.</li>
+        <li><strong>When to revisit:</strong> After Task 9 DoD passes AND the flag has been stable for 2+ weeks on the dogfood workspace. Clustering the current matching signal clusters noise; Discovery is building on sand until 2.6 lands.</li>
         <li><strong>Effort:</strong> Multi-session when it's time.</li>
       </ul>
     </details>
@@ -878,6 +879,27 @@ docker compose exec -T api alembic upgrade head
   <p class="tight" style="color: var(--ink-soft); margin-bottom: 16px;">Newest first; terse. Full forensics live in git commit messages + PR descriptions. Files under <code>docs/session-notes/</code> (sessions 1–7) are historical — no new entries are added there.</p>
 
   <details open>
+    <summary><strong>Session 10 · 2026-04-21</strong> — Phase 2.6 implementation shipped (Tasks 1–8) + <a href="https://github.com/nischal94/sonar/issues/120">#120</a> blocker fix</summary>
+    <ul style="margin:12px 0 4px; padding-left:20px; color: var(--ink-soft);">
+      <li><strong>Open:</strong> <a href="https://github.com/nischal94/sonar/pull/119">PR #119</a> — 17 commits on <code>feat/phase-2-6-migrations</code>, 186 tests green. Implements all 8 code tasks from <code>docs/phase-2-6/implementation.md</code>: 3 migrations + ORM updates, ICP + seller_mirror prompt module, fit_scorer service, extended <code>/profile/extract</code>, pipeline branch on <code>use_hybrid_scoring</code>, one-shot backfill script, wizard ICP review step + <code>/profile/update-icp</code>, <code>analyze-hybrid</code> calibration subcommand.</li>
+      <li><strong>Discipline:</strong> every task through <code>superpowers:subagent-driven-development</code> with two-stage review (spec + quality). Reviews caught 1 blocking (Task 1 SQL injection in test), 6 important findings, multiple nice-to-haves — all addressed inline or deferred with rationale.</li>
+      <li><strong>Closed:</strong> <a href="https://github.com/nischal94/sonar/issues/120">#120</a> — Phase 2.6 merge blocker (delivery formatters rendering <code>relationship_score=0.0</code> as "Relationship: 0%"). Migration 011 makes the column nullable; hybrid pipeline path passes None; Slack/Telegram/email render "Relationship: N/A (hybrid scoring)".</li>
+      <li><strong>Filed for follow-up:</strong> <a href="https://github.com/nischal94/sonar/issues/121">#121</a> PROMPT_VERSION logging systemic gap, <a href="https://github.com/nischal94/sonar/issues/122">#122</a> wizard per-field dirty flags, <a href="https://github.com/nischal94/sonar/issues/123">#123</a> pipeline fit_score race (idempotent), <a href="https://github.com/nischal94/sonar/issues/124">#124</a> lambda storage pending Task 9 calibration.</li>
+      <li><strong>Task 9 still pending</strong> — operational: run <code>analyze-hybrid</code> for Dwao + CleverTap against the session-8 labeled dataset, pick winning λ, flip <code>use_hybrid_scoring=True</code> only if DoD passes on both. Manual browser walkthrough of the 6-step wizard also required before merge.</li>
+    </ul>
+  </details>
+
+  <details>
+    <summary><strong>Session 9 · 2026-04-20/21</strong> — Phase 2.6 design doc written + first review</summary>
+    <ul style="margin:12px 0 4px; padding-left:20px; color: var(--ink-soft);">
+      <li><strong>Merged:</strong> <a href="https://github.com/nischal94/sonar/pull/114">PR #114</a> — calibration harness + findings + Phase 2.6 evidence pool. Closed <a href="https://github.com/nischal94/sonar/issues/106">#106</a> as superseded by <a href="https://github.com/nischal94/sonar/issues/113">#113</a>.</li>
+      <li><strong>Committed:</strong> <code>14cc237</code> Phase 2.6 design proposal (Fit × Intent hybrid scoring), <code>0d390e7</code> revision after first review. <code>docs/phase-2-6/design.md</code> covers contrastive ICP phrasing with explicit anti-examples, a subtractive seller-mirror term with λ sweep (promoted from Plan B to v1 after review), multiplicative <code>fit × intent</code> combine, three DoD constraints (P@5 ≥ 0.6, Recall ≥ 0.5, zero top-5 competitor leakage), feature-flag rollout.</li>
+      <li><strong>Design retractions from first review:</strong> Dropped the earlier concern that CleverTap calibration would be weaker because the labeler doesn't work there. Confused product thinking — the labeler's domain knowledge is what matters, employment is irrelevant. CleverTap remains a full dual-profile DoD.</li>
+      <li><strong>Implementation plan written:</strong> <code>docs/phase-2-6/implementation.md</code> — 9 tasks with bite-sized TDD steps, exact code snippets, commit messages. Task 9 is operational (flag flip + retire legacy).</li>
+    </ul>
+  </details>
+
+  <details>
     <summary><strong>Session 8 · 2026-04-20</strong> — Login page, scorer fix, and the calibration finding that reshaped Phase 2</summary>
     <ul style="margin:12px 0 4px; padding-left:20px; color: var(--ink-soft);">
       <li><strong>Merged:</strong> <a href="https://github.com/nischal94/sonar/pull/109">PR #109</a> (frontend <code>/login</code> page), <a href="https://github.com/nischal94/sonar/pull/112">PR #112</a> (fixes <a href="https://github.com/nischal94/sonar/issues/105">#105</a> — <code>Connection.relationship_score</code> was forced to 0.5 by ORM default, bypassing <code>DEGREE_BASE_SCORE</code> fallback; migration 007 makes column nullable).</li>

--- a/TODO.md
+++ b/TODO.md
@@ -4,43 +4,43 @@
 
 ---
 
-## Next Session Action Plan (last rewritten 2026-04-20, end of session 8)
+## Next Session Action Plan (last rewritten 2026-04-21, end of session 10)
 
-**State at resume:** `main` HEAD = `481f299` (check with `git log -1`). Tests: 136 backend pass. CI green on `main`. Working tree clean. **PR #114 open** on branch `eval/calibration-v1` with the calibration harness + findings — needs review + merge before session-9 work starts.
+**State at resume:** Branch `feat/phase-2-6-migrations` HEAD = `583154b`. Tests: 186 backend pass. Working tree clean. **PR [#119](https://github.com/nischal94/sonar/pull/119) open** with 17 commits implementing Phase 2.6 Tasks 1–8 plus the #120 blocker fix. Task 9 (operational) is the only pending piece.
 
-### 1. ✅ Review + merge PR #114 (calibration findings)
+### 1. 🔬 Manual browser walkthrough of the 6-step wizard
 
-**What:** Read `eval/calibration/findings-dogfood-martech.md` and `eval/calibration/phase-2.6-evidence.md` on PR #114. If the interpretation holds up, merge. Close issue #106 ("threshold calibration") as superseded by #113 ("matching model not viable — Phase 2.6 required") — reference #113 in the close comment.
-**Why now:** The calibration evidence is currently only on a feature branch. Every subsequent decision depends on it being canonical in `main`. Keeping it unmerged risks losing it or losing the thread.
-**Blocks:** Item 2 (Phase 2.6 brainstorm should reference the merged evidence, not a PR branch).
-**Effort:** 15–30 min (read, merge, close #106).
+**What:** `docker compose up -d frontend && open http://localhost:5173/signals/setup`. Walk all 6 steps: enter "What do you sell?" → **new ICP review step 3** appears showing extracted ICP + seller_mirror → edit each field → proceed to signal generation → accept/reject signals → save. Check browser devtools network tab for `/profile/extract` (returns icp + seller_mirror) and `/profile/update-icp` (fires only if user edited). Take a screenshot for the PR merge record.
+**Why now:** Per CLAUDE.md lessons learned, frontend changes require a human in the browser; `npm run build` proves the bundle compiles, not that React rendering works at runtime. This is the last gate before Task 9's calibration run.
+**Blocks:** Item 2 (calibration run needs confirmed working ICP extraction flow) and item 3 (PR merge).
+**Effort:** 10–15 min.
 
-### 2. 🧭 Phase 2.6 — Fit × Intent scoring design brainstorm (the central session-9 activity)
+### 2. 🎯 Task 9 — run Phase 2.6 calibration + decide flag flip
 
-**What:** Run `superpowers:brainstorming` with the problem framed per issue #113: "design a Fit × Intent hybrid scoring model for Sonar that fixes the failure modes in `eval/calibration/phase-2.6-evidence.md`." Produce `docs/phase-2-6/design.md` covering: the fit-encoder choice (BGE / E5 / OpenAI 3-large with asymmetric prompts), per-connection `fit_score` schema + inputs (headline + company + role vs. ICP profile), how to capture ICP disqualifiers (competitors, vendors in same category), how to combine with intent (multiplicative vs additive), persistence-of-prior-signals (Bayesian bump across posts from same high-intent author), calibration plan (re-use `backend/scripts/calibrate_matching.py`, same 30-post dogfood dataset as "before/after" baseline).
-**Why now:** This is the single most important open question for the product. The calibration proved the current primitive cannot ship. Every other Phase 2 item (Discovery) and Phase 3 item (real-time, CRM, team) depends on matching being meaningful. Nothing matters more than getting this right.
-**Blocks:** Phase 2 Discovery, all Phase 3 work, any launch plan.
-**Effort:** Full session for brainstorming + design doc. Implementation is another 2–3 sessions after.
+**What:** For both Dwao and CleverTap workspaces: extract ICP via `/profile/extract`, run `python scripts/backfill_fit_scores.py --workspace-id <uuid>`, then `python scripts/calibrate_matching.py analyze-hybrid --workspace-id <uuid> --labels eval/calibration/<dataset>.md --lambdas 0.0,0.1,0.2,0.3,0.5,0.7,1.0`. For CleverTap, re-label the same 30-post dogfood dataset under the CleverTap lens first (~15 min). Pick the winning λ that satisfies DoD on BOTH workspaces: P@5 ≥ 0.6, Recall@5 ≥ 0.5, zero top-5 competitors. Document findings at `eval/calibration/phase-2-6-findings.md`.
+**Why now:** This is the ship/don't-ship gate for Phase 2.6. The implementation is shippable code; whether it actually improves matching is an empirical question only calibration answers. If DoD fails, see design.md §5 step 8 for diagnostic paths (encoder upgrade, prompt tightening, retrieval-model swap).
+**Blocks:** flag flip on dogfood workspace. PR #119 can merge independently of calibration outcome, but the flag flip is the operational goal.
+**Effort:** 1–2 hours (ICP extraction × 2 workspaces, backfill × 2, analyze-hybrid × 2, CleverTap re-label, write findings).
 
-### 3. 🔒 Hardening: issues #107 + #108 (do before first external user)
+### 3. 🚀 Merge PR #119 + flip the flag for dogfood workspace
 
-**#107 — CORS service-worker routing.** Route extension fetches through the background service worker (whose origin is `chrome-extension://<id>`, already allowed). Remove `https://www.linkedin.com` from `app/main.py` `allow_origins`. Closes the `/auth/token` response-read exposure the session-7 CORS widening created. **Effort:** ~1 hour.
+**What:** After items 1 + 2 pass, merge PR #119 to main. Then `UPDATE workspaces SET use_hybrid_scoring = TRUE WHERE id = '<Dwao_uuid>';`. Monitor `/dashboard` output and delivered alerts for 1–2 weeks against the session-8 calibration baseline.
+**Why now:** The Phase 2.6 code is inert until the flag flips. The rollout design is per-workspace so rollback is a single SQL flip.
+**Effort:** 5 min to merge + flip. 1–2 weeks monitoring.
 
-**#108 — Apify token to `Authorization` header.** Move from URL query param (`?token=apify_api_...`) to `Authorization: Bearer` header in `app/services/apify.py`. Verify harvestapi accepts header auth. Stops the plaintext-token leak into every worker log line. **Effort:** ~30 minutes.
+### 4. 🛠 Address Phase 2.6 follow-up issues (any time, low-to-medium effort)
 
-**Why now:** Both are security-adjacent and small. Best done in one commit *before* any external user signs up. Not blocked on Phase 2.6 — can ship in parallel or in a gap between brainstorm and implementation.
+- [#121](https://github.com/nischal94/sonar/issues/121) — log `PROMPT_VERSION` on every LLM call. Systemic tech debt; also affects the existing `extract_capability_profile`.
+- [#122](https://github.com/nischal94/sonar/issues/122) — wizard: split `icpEdited` into per-field dirty flags (avoid redundant re-embed on unchanged field). UX polish.
+- [#123](https://github.com/nischal94/sonar/issues/123) — pipeline race on `connection.fit_score` cache. Idempotent outcome; low priority until traffic scales.
+- [#124](https://github.com/nischal94/sonar/issues/124) — add `workspace.hybrid_lambda` column if Task 9 picks λ ≠ 0.3. Close as "no action needed" if Task 9 picks 0.3.
 
-### 4. 🛠 Small quality fixes (any time, low effort)
+Also deferred from session 8: [#107](https://github.com/nischal94/sonar/issues/107) CORS service-worker routing, [#108](https://github.com/nischal94/sonar/issues/108) Apify token to Authorization header, [#110](https://github.com/nischal94/sonar/issues/110) Ring 1 dead, [#111](https://github.com/nischal94/sonar/issues/111) dashboard slider default. None block Phase 2.6.
 
-- **#110 — Ring 1 dead.** Signals are full phrases; Ring 1 does literal substring match; produces zero hits. Partially overlaps with Phase 2.6 (may disappear if Phase 2.6 reshapes what a "signal" is). Decide in Phase 2.6 design whether to fix standalone or fold in.
-- **#111 — Dashboard slider default (0.65) ignores workspace `matching_threshold`.** Small frontend fix: pass the workspace's stored threshold on initial render. ~30 minutes. Not urgent.
-- **Dogfood DB cleanup (per PR #112 body).** Run `UPDATE connections SET relationship_score = NULL WHERE relationship_score = 0.5 AND NOT has_interacted;` on the dogfood workspace to let the fixed scorer see correct values. Already done in session 8; noted here in case a fresh environment is restored from a snapshot.
-
-### 5. 🧭 Phase 2 Discovery (DEFERRED until Phase 2.6 ships)
+### 5. 🧭 Phase 2 Discovery (DEFERRED until Phase 2.6 DoD passes)
 
 **What:** Ring 3 nightly HDBSCAN clustering for emerging topics + Weekly Digest Email. Per `docs/phase-2/design.md §4.4`.
-**Why not now:** Clustering posts by the current matching signal clusters noise (F1 = 0.27). Discovery is building on sand until Phase 2.6 lands.
-**When to revisit:** After Phase 2.6 ships *and* re-calibration against the dogfood dataset produces F1 ≥ 0.6.
+**When to revisit:** After Task 9 DoD passes AND the flag has been stable for 2+ weeks on the dogfood workspace. Clustering the current matching signal clusters noise; Discovery is building on sand until 2.6 lands.
 **Effort:** Multi-session when it's time.
 
 ### 6. 🚧 Pre-launch tier (gates before first external paying customer — NOT next-session work)
@@ -49,9 +49,7 @@ Tracked so they don't surprise:
 - **PII/GDPR:** data retention policy + export + deletion endpoints. Not started.
 - **Observability:** structlog + Sentry + Prometheus + split `/health/live` vs `/ready` + DB backup/restore drill. Not started.
 - **LLM eval harness:** activates once `signal_proposal_events` has ~100+ real completions.
-- **Frontend dep bumps:** React 18→19, Vite 6→8, react-router-dom 6→7. Tracked in #40. Requires human in browser — plan a dedicated half-day.
-
-None of these belong in session 9; all gate first external customer.
+- **Frontend dep bumps:** React 18→19, Vite 6→8, react-router-dom 6→7. Tracked in [#40](https://github.com/nischal94/sonar/issues/40). Requires human in browser — plan a dedicated half-day.
 
 ---
 
@@ -136,6 +134,21 @@ Run `superpowers:brainstorming` with "scope Phase 3 of Sonar — real-time alert
 ---
 
 ## Session log (newest first, terse; full forensics live in git commits + PR descriptions)
+
+### Session 10 — 2026-04-21 — Phase 2.6 implementation shipped (Tasks 1–8) + #120 blocker fix
+
+- **Open:** [PR #119](https://github.com/nischal94/sonar/pull/119) — 17 commits on `feat/phase-2-6-migrations`, 186 tests green. Implements all 8 code tasks from `docs/phase-2-6/implementation.md`: 3 migrations + ORM updates, ICP + seller_mirror prompt module, fit_scorer service, extended `/profile/extract`, pipeline branch on `use_hybrid_scoring`, one-shot backfill script, wizard ICP review step + `/profile/update-icp`, `analyze-hybrid` calibration subcommand.
+- **Discipline:** every task through `superpowers:subagent-driven-development` with two-stage review (spec + quality). Reviews caught 1 blocking (Task 1 SQL injection in test), 6 important findings, multiple nice-to-haves — all addressed inline or deferred with rationale.
+- **Closed:** [#120](https://github.com/nischal94/sonar/issues/120) — Phase 2.6 merge blocker (delivery formatters rendering `relationship_score=0.0` as "Relationship: 0%"). Migration 011 makes the column nullable; hybrid pipeline path passes None; Slack/Telegram/email render "Relationship: N/A (hybrid scoring)".
+- **Filed for follow-up:** [#121](https://github.com/nischal94/sonar/issues/121) PROMPT_VERSION logging systemic gap, [#122](https://github.com/nischal94/sonar/issues/122) wizard per-field dirty flags, [#123](https://github.com/nischal94/sonar/issues/123) pipeline fit_score race (idempotent), [#124](https://github.com/nischal94/sonar/issues/124) lambda storage pending Task 9 calibration.
+- **Task 9 still pending** — operational: run `analyze-hybrid` for Dwao + CleverTap against the session-8 labeled dataset, pick winning λ, flip `use_hybrid_scoring=True` only if DoD passes on both workspaces. Manual browser walkthrough of the 6-step wizard also required before merge.
+
+### Session 9 — 2026-04-20/21 — Phase 2.6 design doc written + first review
+
+- **Merged:** [PR #114](https://github.com/nischal94/sonar/pull/114) — calibration harness + findings + Phase 2.6 evidence pool. Closed [#106](https://github.com/nischal94/sonar/issues/106) as superseded by [#113](https://github.com/nischal94/sonar/issues/113).
+- **Committed:** `14cc237` Phase 2.6 design proposal (Fit × Intent hybrid scoring), `0d390e7` revision after first review. `docs/phase-2-6/design.md` covers contrastive ICP phrasing with explicit anti-examples, a subtractive seller-mirror term with λ sweep (promoted from Plan B to v1 after review), multiplicative `fit × intent` combine, three DoD constraints (P@5 ≥ 0.6, Recall ≥ 0.5, zero top-5 competitor leakage), feature-flag rollout.
+- **Design retractions from first review:** Dropped the earlier concern that CleverTap calibration would be weaker because the labeler doesn't work there. That was confused product thinking — the labeler's domain knowledge is what matters, employment is irrelevant. CleverTap remains a full dual-profile DoD.
+- **Implementation plan written:** `docs/phase-2-6/implementation.md` — 9 tasks with bite-sized TDD steps, exact code snippets, commit messages. Task 9 is operational (flag flip + retire legacy).
 
 ### Session 8 — 2026-04-20 — Login page, scorer fix, and the calibration finding that reshaped Phase 2
 

--- a/backend/alembic/versions/008_connection_fit_score.py
+++ b/backend/alembic/versions/008_connection_fit_score.py
@@ -1,4 +1,20 @@
-"""Add fit_score to connections (Phase 2.6).
+"""connections.fit_score — per-connection ICP fit for Phase 2.6 hybrid scoring.
+
+Phase 2.6 replaces single-axis post-similarity matching with a two-axis
+hybrid: final_score = fit_score × intent_score. fit_score is computed per
+connection as cos(ICP, conn) - λ · cos(seller_mirror, conn), where ICP and
+seller_mirror are LLM-extracted from the workspace's source text and conn
+is the embedding of headline + company. Writers: the pipeline (on first
+encounter of a workspace using hybrid) and scripts/backfill_fit_scores.py.
+
+Nullable because existing workspaces on legacy scoring never populate it,
+and new hybrid-workspace connections are populated lazily on first scoring.
+
+Type matches existing relationship_score on the same table (sa.Float →
+Postgres double precision) for schema consistency across connection-level
+score columns.
+
+See docs/phase-2-6/design.md §3.2.
 
 Revision ID: 008
 Revises: 007
@@ -18,7 +34,7 @@ depends_on = None
 def upgrade() -> None:
     op.add_column(
         "connections",
-        sa.Column("fit_score", sa.REAL(), nullable=True),
+        sa.Column("fit_score", sa.Float(), nullable=True),
     )
 
 

--- a/backend/alembic/versions/008_connection_fit_score.py
+++ b/backend/alembic/versions/008_connection_fit_score.py
@@ -1,0 +1,26 @@
+"""Add fit_score to connections (Phase 2.6).
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-04-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "008"
+down_revision = "007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "connections",
+        sa.Column("fit_score", sa.REAL(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("connections", "fit_score")

--- a/backend/alembic/versions/009_workspace_use_hybrid_scoring.py
+++ b/backend/alembic/versions/009_workspace_use_hybrid_scoring.py
@@ -1,0 +1,31 @@
+"""Add use_hybrid_scoring flag to workspaces (Phase 2.6).
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-04-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "use_hybrid_scoring",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "use_hybrid_scoring")

--- a/backend/alembic/versions/009_workspace_use_hybrid_scoring.py
+++ b/backend/alembic/versions/009_workspace_use_hybrid_scoring.py
@@ -1,4 +1,18 @@
-"""Add use_hybrid_scoring flag to workspaces (Phase 2.6).
+"""workspaces.use_hybrid_scoring — feature flag for Phase 2.6 hybrid scorer.
+
+When FALSE (the default for every existing row), the pipeline uses the
+legacy compute_combined_score (relevance × relationship × timing). When
+TRUE, the pipeline uses compute_hybrid_score (fit × intent) and reads
+connection.fit_score + profile.icp_embedding + profile.seller_mirror_embedding.
+
+Rollout: new workspaces default to FALSE. Operators flip per-workspace
+after running /profile/extract (populates ICP + seller_mirror embeddings)
+and scripts/backfill_fit_scores.py (populates connection.fit_score). After
+the dogfood workspace is stable for one release cycle, a future migration
+can switch the column default to TRUE and the legacy scorer can be retired.
+
+NOT NULL with server_default=false so the migration runs in O(1) on
+existing rows (no table rewrite). See docs/phase-2-6/design.md §3.7.
 
 Revision ID: 009
 Revises: 008

--- a/backend/alembic/versions/010_icp_and_seller_mirror.py
+++ b/backend/alembic/versions/010_icp_and_seller_mirror.py
@@ -1,0 +1,41 @@
+"""Add icp, seller_mirror, and their embeddings to capability_profile_versions (Phase 2.6).
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-04-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+
+revision = "010"
+down_revision = "009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "capability_profile_versions", sa.Column("icp", sa.Text(), nullable=True)
+    )
+    op.add_column(
+        "capability_profile_versions",
+        sa.Column("seller_mirror", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "capability_profile_versions",
+        sa.Column("icp_embedding", Vector(1536), nullable=True),
+    )
+    op.add_column(
+        "capability_profile_versions",
+        sa.Column("seller_mirror_embedding", Vector(1536), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("capability_profile_versions", "seller_mirror_embedding")
+    op.drop_column("capability_profile_versions", "icp_embedding")
+    op.drop_column("capability_profile_versions", "seller_mirror")
+    op.drop_column("capability_profile_versions", "icp")

--- a/backend/alembic/versions/010_icp_and_seller_mirror.py
+++ b/backend/alembic/versions/010_icp_and_seller_mirror.py
@@ -1,4 +1,21 @@
-"""Add icp, seller_mirror, and their embeddings to capability_profile_versions (Phase 2.6).
+"""capability_profile_versions — add ICP + seller_mirror paragraphs + embeddings.
+
+Phase 2.6 extracts two paragraphs from a workspace's source text via
+app/prompts/extract_icp_and_seller_mirror.py:
+  - icp: who the workspace's buyer is — role, seniority, company shape,
+    contrastively phrased with explicit non-buyers named.
+  - seller_mirror: what OTHER sellers of the same capability look like on
+    LinkedIn. Subtracted from the ICP similarity during fit scoring to
+    suppress competing-vendor leakage.
+
+Both are embedded via text-embedding-3-small (1536 dims — must match the
+existing `embedding` column dimension so cosine math stays consistent).
+
+All four columns nullable: existing profile versions pre-Phase-2.6 don't
+have them, and the pipeline's hybrid branch falls back to the legacy
+scorer if either embedding is NULL (see app/workers/pipeline.py).
+
+See docs/phase-2-6/design.md §3.2 + §4.3.
 
 Revision ID: 010
 Revises: 009

--- a/backend/alembic/versions/011_alert_relationship_score_nullable.py
+++ b/backend/alembic/versions/011_alert_relationship_score_nullable.py
@@ -1,0 +1,62 @@
+"""alerts.relationship_score — make nullable for hybrid scoring
+
+In the legacy scoring path, relationship_score is a meaningful 0–1 value
+derived from connection degree (1st=0.90, 2nd=0.60, 3rd=0.30) plus any
+interaction boost.  It is written into the Alert row and surfaced in every
+delivery formatter (Slack, Telegram, email).
+
+In the Phase 2.6 hybrid scoring path (workspace.use_hybrid_scoring=True),
+the relationship dimension is replaced by the Fit × Intent composite.
+Network-degree filtering happens on the dashboard, not inside the scorer.
+The hybrid pipeline sets scoring.relationship_score=0.0 as a placeholder,
+and that 0.0 flows into the Alert row and renders as "Relationship: 0%" in
+every delivery channel — which is misleading and looks broken.
+
+Fix: make the column nullable.  The hybrid pipeline passes
+relationship_score=None when constructing the Alert; the three delivery
+formatters (slack.py, telegram.py, email.py) omit the field when it is
+None.  Legacy workspaces are unaffected — they still receive a float value
+and see the rendered percentage as before.
+
+NULL in this column therefore means "this alert was scored via the hybrid
+Fit × Intent path; the relationship axis does not apply."  A non-NULL value
+means the legacy path ran and the percentage is meaningful.
+
+See issue #120 for the full context.  Introduced in Phase 2.6 (PR #119).
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-04-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "011"
+down_revision = "010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "alerts",
+        "relationship_score",
+        existing_type=sa.Float(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Back-fill NULLs with 0.0 before restoring the NOT NULL constraint.
+    # Hybrid-mode alerts had no meaningful relationship score; 0.0 is the
+    # least-bad sentinel for the legacy schema that requires a value.
+    op.execute(
+        "UPDATE alerts SET relationship_score = 0.0 WHERE relationship_score IS NULL"
+    )
+    op.alter_column(
+        "alerts",
+        "relationship_score",
+        existing_type=sa.Float(),
+        nullable=False,
+    )

--- a/backend/app/delivery/email.py
+++ b/backend/app/delivery/email.py
@@ -20,6 +20,11 @@ class EmailSender:
         )
         subject = f"{priority_emoji} Sonar Signal — {alert.opportunity_type.replace('_', ' ').title()}"
 
+        relationship_segment = (
+            f"Relationship: {alert.relationship_score:.0%} | "
+            if alert.relationship_score is not None
+            else ""
+        )
         html = f"""
         <h2>{priority_emoji} {alert.priority.upper()} SIGNAL</h2>
         <p><strong>Why it matches:</strong><br>{alert.match_reason}</p>
@@ -30,8 +35,7 @@ class EmailSender:
         <hr>
         <p>
             Scores — Relevance: {alert.relevance_score:.0%} |
-            Relationship: {alert.relationship_score:.0%} |
-            Timing: {alert.timing_score:.0%} |
+            {relationship_segment}Timing: {alert.timing_score:.0%} |
             Combined: {alert.combined_score:.0%}
         </p>
         """

--- a/backend/app/delivery/slack.py
+++ b/backend/app/delivery/slack.py
@@ -20,30 +20,51 @@ class SlackSender:
         blocks = [
             {
                 "type": "header",
-                "text": {"type": "plain_text", "text": f"{emoji} {alert.priority.upper()} SIGNAL"}
-            },
-            {
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": f"*Why it matches:*\n{alert.match_reason}"}
+                "text": {
+                    "type": "plain_text",
+                    "text": f"{emoji} {alert.priority.upper()} SIGNAL",
+                },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": (
-                        f"Relevance: `{_score_bar(alert.relevance_score)}` {alert.relevance_score:.0%}\n"
-                        f"Relationship: `{_score_bar(alert.relationship_score)}` {alert.relationship_score:.0%}\n"
-                        f"Timing: `{_score_bar(alert.timing_score)}` {alert.timing_score:.0%}"
-                    )
-                }
+                    "text": f"*Why it matches:*\n{alert.match_reason}",
+                },
             },
             {
                 "type": "section",
-                "text": {"type": "mrkdwn", "text": f"*Draft A (Direct):*\n_{alert.outreach_draft_a}_"}
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\n".join(
+                        filter(
+                            None,
+                            [
+                                f"Relevance: `{_score_bar(alert.relevance_score)}` {alert.relevance_score:.0%}",
+                                (
+                                    f"Relationship: `{_score_bar(alert.relationship_score)}` {alert.relationship_score:.0%}"
+                                    if alert.relationship_score is not None
+                                    else None
+                                ),
+                                f"Timing: `{_score_bar(alert.timing_score)}` {alert.timing_score:.0%}",
+                            ],
+                        )
+                    ),
+                },
             },
             {
                 "type": "section",
-                "text": {"type": "mrkdwn", "text": f"*Draft B (Question):*\n_{alert.outreach_draft_b}_"}
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Draft A (Direct):*\n_{alert.outreach_draft_a}_",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Draft B (Question):*\n_{alert.outreach_draft_b}_",
+                },
             },
             {
                 "type": "actions",
@@ -52,15 +73,15 @@ class SlackSender:
                         "type": "button",
                         "text": {"type": "plain_text", "text": "✓ Acted"},
                         "action_id": f"acted_{alert.id}",
-                        "style": "primary"
+                        "style": "primary",
                     },
                     {
                         "type": "button",
                         "text": {"type": "plain_text", "text": "✗ Not Relevant"},
-                        "action_id": f"irrelevant_{alert.id}"
-                    }
-                ]
-            }
+                        "action_id": f"irrelevant_{alert.id}",
+                    },
+                ],
+            },
         ]
 
         async with httpx.AsyncClient() as client:

--- a/backend/app/delivery/telegram.py
+++ b/backend/app/delivery/telegram.py
@@ -10,7 +10,7 @@ def _score_bar(score: float, width: int = 10) -> str:
 
 def _escape_mdv2(text: str) -> str:
     """Escape special characters for Telegram MarkdownV2."""
-    return re.sub(r'([_*\[\]()~`>#+\-=|{}.!\\])', r'\\\1', text)
+    return re.sub(r"([_*\[\]()~`>#+\-=|{}.!\\])", r"\\\1", text)
 
 
 class TelegramSender:
@@ -25,22 +25,31 @@ class TelegramSender:
 
         emoji = {"high": "🔴", "medium": "🟡", "low": "🟢"}.get(alert.priority, "⚪")
 
+        relationship_line = (
+            f"📊 Relationship: `{_score_bar(alert.relationship_score)}` {alert.relationship_score:.0%}\n"
+            if alert.relationship_score is not None
+            else ""
+        )
         text = (
             f"{emoji} *{alert.priority.upper()} SIGNAL*\n\n"
             f"🎯 *Why it matches:*\n{_escape_mdv2(alert.match_reason)}\n\n"
             f"📊 Relevance: `{_score_bar(alert.relevance_score)}` {alert.relevance_score:.0%}\n"
-            f"📊 Relationship: `{_score_bar(alert.relationship_score)}` {alert.relationship_score:.0%}\n"
+            f"{relationship_line}"
             f"📊 Timing: `{_score_bar(alert.timing_score)}` {alert.timing_score:.0%}\n\n"
             f"✉️ *Draft A \\(Direct\\):*\n_{_escape_mdv2(alert.outreach_draft_a)}_\n\n"
             f"✉️ *Draft B \\(Question\\):*\n_{_escape_mdv2(alert.outreach_draft_b)}_"
         )
 
-        keyboard = InlineKeyboardMarkup([
+        keyboard = InlineKeyboardMarkup(
             [
-                InlineKeyboardButton("✓ Acted", callback_data=f"acted_{alert.id}"),
-                InlineKeyboardButton("✗ Not Relevant", callback_data=f"irrelevant_{alert.id}")
+                [
+                    InlineKeyboardButton("✓ Acted", callback_data=f"acted_{alert.id}"),
+                    InlineKeyboardButton(
+                        "✗ Not Relevant", callback_data=f"irrelevant_{alert.id}"
+                    ),
+                ]
             ]
-        ])
+        )
 
         await self._bot.send_message(
             chat_id=chat_id,

--- a/backend/app/models/alert.py
+++ b/backend/app/models/alert.py
@@ -4,6 +4,7 @@ from app.models._types import TIMESTAMPTZ
 import uuid
 from app.database import Base
 
+
 class Alert(Base):
     __tablename__ = "alerts"
 
@@ -12,7 +13,7 @@ class Alert(Base):
     post_id = Column(UUID(as_uuid=True), nullable=False)
     connection_id = Column(UUID(as_uuid=True), nullable=False)
     relevance_score = Column(Float, nullable=False)
-    relationship_score = Column(Float, nullable=False)
+    relationship_score = Column(Float, nullable=True)
     timing_score = Column(Float, nullable=False)
     combined_score = Column(Float, nullable=False)
     priority = Column(String, nullable=False)

--- a/backend/app/models/connection.py
+++ b/backend/app/models/connection.py
@@ -35,6 +35,7 @@ class Connection(Base):
     degree = Column(Integer, nullable=False)
     mutual_count = Column(Integer, nullable=False, default=0, server_default="0")
     relationship_score = Column(Float, nullable=True)
+    fit_score = Column(Float, nullable=True)
     has_interacted = Column(Boolean, nullable=False, default=False)
     first_seen_at = Column(TIMESTAMPTZ, nullable=False, server_default="now()")
     last_active_at = Column(TIMESTAMPTZ)

--- a/backend/app/models/workspace.py
+++ b/backend/app/models/workspace.py
@@ -15,6 +15,9 @@ class Workspace(Base):
     plan_tier = Column(String, nullable=False, default="starter")
     capability_profile = Column(Text)
     matching_threshold = Column(Float, nullable=False, default=0.72)
+    use_hybrid_scoring = Column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
     scoring_weights = Column(
         JSONB, default=lambda: {"relevance": 0.50, "relationship": 0.30, "timing": 0.20}
     )
@@ -48,6 +51,10 @@ class CapabilityProfileVersion(Base):
     source = Column(String, nullable=False)
     signal_keywords = Column(ARRAY(Text))
     anti_keywords = Column(ARRAY(Text))
+    icp = Column(Text, nullable=True)
+    seller_mirror = Column(Text, nullable=True)
+    icp_embedding = Column(Vector(1536), nullable=True)
+    seller_mirror_embedding = Column(Vector(1536), nullable=True)
     is_active = Column(Boolean, nullable=False, default=True)
     performance_score = Column(Float)
     embedding = Column(Vector(1536))

--- a/backend/app/prompts/__init__.py
+++ b/backend/app/prompts/__init__.py
@@ -1,0 +1,36 @@
+"""Shared utilities for prompt modules.
+
+All LLM call sites that have a prompt module should call `log_prompt_call`
+immediately after a successful LLM response so every real call is traceable
+in structured logs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+_logger = logging.getLogger("app.prompts")
+
+
+def log_prompt_call(
+    feature: str,
+    prompt_version: str,
+    model: str,
+    **extra: Any,
+) -> None:
+    """Emit a structured INFO log after a successful LLM call.
+
+    Args:
+        feature: Name of the feature / call site (e.g. "propose_signals").
+        prompt_version: The PROMPT_VERSION constant from the prompt module.
+        model: The model identifier used for this call.
+        **extra: Optional context fields such as workspace_id.
+    """
+    payload: dict[str, Any] = {
+        "feature": feature,
+        "prompt_version": prompt_version,
+        "model": model,
+    }
+    payload.update(extra)
+    _logger.info("llm_call", extra={"prompt_log": payload})

--- a/backend/app/prompts/extract_icp_and_seller_mirror.py
+++ b/backend/app/prompts/extract_icp_and_seller_mirror.py
@@ -17,7 +17,7 @@ like on LinkedIn.
 
 Rules for the ICP paragraph:
 1. Name the buyer's role, seniority, and company shape (industry, stage, size).
-2. Phrase contrastively -- explicitly name who the buyer is NOT. Example: "Not
+2. Phrase contrastively — explicitly name who the buyer is NOT. Example: "Not
    employees of martech SaaS vendors or competing agencies."
 3. Written in plain English. No bullet lists, no headers. One dense paragraph.
 4. 50-120 words.
@@ -25,7 +25,7 @@ Rules for the ICP paragraph:
 Rules for the seller-mirror paragraph:
 1. Describe what other SELLERS of this same capability look like on LinkedIn.
    Who would a competitor's founder, CEO, CPO, or sales director look like?
-2. Focus on linguistic tells in LinkedIn headlines -- product name-drops,
+2. Focus on linguistic tells in LinkedIn headlines — product name-drops,
    stage signals ("Series B", "YC W22"), role words ("CEO", "Founder",
    "Head of Sales at X").
 3. This paragraph is SUBTRACTED from the ICP signal during scoring, so

--- a/backend/app/prompts/extract_icp_and_seller_mirror.py
+++ b/backend/app/prompts/extract_icp_and_seller_mirror.py
@@ -7,6 +7,8 @@ capability_profile_versions.
 PROMPT_VERSION: bump on every content change. Logged alongside every call.
 """
 
+from __future__ import annotations
+
 PROMPT_VERSION = "v1"
 
 SYSTEM_PROMPT = """You are a B2B sales intelligence analyst. Given a company's
@@ -57,13 +59,13 @@ RESPONSE_JSON_SCHEMA = {
     "properties": {
         "icp": {
             "type": "string",
-            "minLength": 80,
-            "maxLength": 1200,
+            "minLength": 200,
+            "maxLength": 800,
         },
         "seller_mirror": {
             "type": "string",
-            "minLength": 80,
-            "maxLength": 1200,
+            "minLength": 200,
+            "maxLength": 800,
         },
     },
     "required": ["icp", "seller_mirror"],

--- a/backend/app/prompts/extract_icp_and_seller_mirror.py
+++ b/backend/app/prompts/extract_icp_and_seller_mirror.py
@@ -1,0 +1,71 @@
+"""Extract ICP paragraph + seller-mirror paragraph from a workspace's source text.
+
+Single dual-output prompt per design §3.2 and §8. Outputs are consumed by
+profile_extractor to persist icp / seller_mirror text + embeddings on
+capability_profile_versions.
+
+PROMPT_VERSION: bump on every content change. Logged alongside every call.
+"""
+
+PROMPT_VERSION = "v1"
+
+SYSTEM_PROMPT = """You are a B2B sales intelligence analyst. Given a company's
+self-description (from their website, a sales playbook, or a typed summary),
+your job is to produce two paragraphs that describe (a) who that company's
+buyers are and (b) what OTHER companies that sell the SAME capability look
+like on LinkedIn.
+
+Rules for the ICP paragraph:
+1. Name the buyer's role, seniority, and company shape (industry, stage, size).
+2. Phrase contrastively -- explicitly name who the buyer is NOT. Example: "Not
+   employees of martech SaaS vendors or competing agencies."
+3. Written in plain English. No bullet lists, no headers. One dense paragraph.
+4. 50-120 words.
+
+Rules for the seller-mirror paragraph:
+1. Describe what other SELLERS of this same capability look like on LinkedIn.
+   Who would a competitor's founder, CEO, CPO, or sales director look like?
+2. Focus on linguistic tells in LinkedIn headlines -- product name-drops,
+   stage signals ("Series B", "YC W22"), role words ("CEO", "Founder",
+   "Head of Sales at X").
+3. This paragraph is SUBTRACTED from the ICP signal during scoring, so
+   precision matters: describe the seller-shape as specifically as you can.
+4. 50-120 words.
+
+Return strict JSON with exactly two keys: icp and seller_mirror. No other keys,
+no prose outside the JSON."""
+
+
+def build_user_message(source_text: str) -> str:
+    """Compose the user turn. This is the only place user input is interpolated.
+
+    Raises ValueError if source_text is empty or whitespace-only.
+    """
+    if not source_text or not source_text.strip():
+        raise ValueError("source_text must be non-empty")
+    return (
+        "Here is the company's self-description. Produce the ICP and seller-mirror "
+        "paragraphs per the rules.\n\n"
+        "---\n"
+        f"{source_text.strip()}\n"
+        "---"
+    )
+
+
+RESPONSE_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "icp": {
+            "type": "string",
+            "minLength": 80,
+            "maxLength": 1200,
+        },
+        "seller_mirror": {
+            "type": "string",
+            "minLength": 80,
+            "maxLength": 1200,
+        },
+    },
+    "required": ["icp", "seller_mirror"],
+    "additionalProperties": False,
+}

--- a/backend/app/routers/profile.py
+++ b/backend/app/routers/profile.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update, func, text
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl
 from app.database import get_db
 from app.models.workspace import Workspace, CapabilityProfileVersion
 from app.models.user import User
@@ -31,8 +31,10 @@ class ProfileExtractResponse(BaseModel):
 
 
 class UpdateIcpRequest(BaseModel):
-    icp: str | None = None
-    seller_mirror: str | None = None
+    # max_length ~4000 chars ≈ well under text-embedding-3-small's 8191-token
+    # window and keeps a single request from burning unbounded LLM cost.
+    icp: str | None = Field(default=None, max_length=4000)
+    seller_mirror: str | None = Field(default=None, max_length=4000)
 
 
 @router.post("/extract", response_model=ProfileExtractResponse)
@@ -140,11 +142,19 @@ async def update_icp(
 ):
     """Update the active CapabilityProfileVersion's ICP and/or seller_mirror text.
 
-    Re-embeds whichever fields are provided. At least one field must be present.
-    The active version is identified by workspace_id + is_active=True.
+    Re-embeds whichever fields are provided. At least one field must be a
+    non-whitespace string. The active version is identified by
+    workspace_id + is_active=True.
     """
-    if not body.icp and not body.seller_mirror:
-        raise HTTPException(status_code=400, detail="Provide icp and/or seller_mirror")
+    # Normalize: strip whitespace, treat "" and "   " as equivalent to missing.
+    # Pydantic's max_length guards the upper bound; this guards the lower.
+    icp_clean = body.icp.strip() if body.icp else None
+    mirror_clean = body.seller_mirror.strip() if body.seller_mirror else None
+    if not icp_clean and not mirror_clean:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide at least one non-empty icp or seller_mirror",
+        )
 
     # Resolve the active version id first
     id_result = await db.execute(
@@ -158,12 +168,19 @@ async def update_icp(
             status_code=404, detail="No active capability profile found"
         )
 
-    # Update text fields via ORM (no vector columns here)
+    # Phase 1 — compute all embeddings FIRST, before any DB writes. If any
+    # embed() call raises (network, 429, 500), no partial write escapes.
+    # Do not re-order this block to interleave embeds with SQL writes.
+    icp_embedding = await emb.embed(icp_clean) if icp_clean else None
+    mirror_embedding = await emb.embed(mirror_clean) if mirror_clean else None
+
+    # Phase 2 — issue all DB writes in the same transaction. SQLAlchemy
+    # rolls back if any step below raises before commit.
     text_fields: dict = {}
-    if body.icp:
-        text_fields["icp"] = body.icp
-    if body.seller_mirror:
-        text_fields["seller_mirror"] = body.seller_mirror
+    if icp_clean:
+        text_fields["icp"] = icp_clean
+    if mirror_clean:
+        text_fields["seller_mirror"] = mirror_clean
 
     await db.execute(
         update(CapabilityProfileVersion)
@@ -171,17 +188,14 @@ async def update_icp(
         .values(**text_fields)
     )
 
-    # Re-embed via parameterized raw SQL (same pattern as /profile/extract)
     set_clauses = []
     params: dict = {"id": str(version_id)}
-    if body.icp:
-        icp_embedding = await emb.embed(body.icp)
+    if icp_embedding is not None:
         set_clauses.append("icp_embedding = :icp_emb")
         params["icp_emb"] = str(icp_embedding)
-    if body.seller_mirror:
-        seller_mirror_embedding = await emb.embed(body.seller_mirror)
+    if mirror_embedding is not None:
         set_clauses.append("seller_mirror_embedding = :mirror_emb")
-        params["mirror_emb"] = str(seller_mirror_embedding)
+        params["mirror_emb"] = str(mirror_embedding)
 
     await db.execute(
         text(

--- a/backend/app/routers/profile.py
+++ b/backend/app/routers/profile.py
@@ -2,12 +2,14 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update, func, text
 from pydantic import BaseModel, HttpUrl
-from uuid import UUID
 from app.database import get_db
 from app.models.workspace import Workspace, CapabilityProfileVersion
 from app.models.user import User
 from app.routers.auth import get_current_user
-from app.services.profile_extractor import extract_capability_profile
+from app.services.profile_extractor import (
+    extract_capability_profile,
+    extract_icp_and_seller_mirror,
+)
 from app.services.embedding import EmbeddingProvider, get_embedding_provider
 from app.services.llm import LLMProvider, get_llm_client
 
@@ -24,6 +26,8 @@ class ProfileExtractResponse(BaseModel):
     capability_summary: str
     signal_keywords: list[str]
     version: int
+    icp: str
+    seller_mirror: str
 
 
 @router.post("/extract", response_model=ProfileExtractResponse)
@@ -45,17 +49,29 @@ async def extract_profile(
 
     embedding = await emb.embed(profile.capability_summary)
 
+    # Source text for ICP extraction: prefer the user-provided text; if only a
+    # URL was given, the capability summary itself is a faithful summary of
+    # what the crawler found and is a reasonable substitute.
+    icp_source_text = body.text or profile.capability_summary
+    icp_text, seller_mirror_text = await extract_icp_and_seller_mirror(
+        source_text=icp_source_text,
+        llm_override=llm,
+    )
+    icp_embedding = await emb.embed(icp_text)
+    seller_mirror_embedding = await emb.embed(seller_mirror_text)
+
     # Deactivate previous active version
     await db.execute(
         update(CapabilityProfileVersion)
         .where(CapabilityProfileVersion.workspace_id == current_user.workspace_id)
-        .where(CapabilityProfileVersion.is_active == True)
+        .where(CapabilityProfileVersion.is_active.is_(True))
         .values(is_active=False)
     )
 
     # Count existing versions to determine next version number
     count_result = await db.execute(
-        select(func.count()).select_from(CapabilityProfileVersion)
+        select(func.count())
+        .select_from(CapabilityProfileVersion)
         .where(CapabilityProfileVersion.workspace_id == current_user.workspace_id)
     )
     version_number = (count_result.scalar() or 0) + 1
@@ -67,6 +83,8 @@ async def extract_profile(
         source="url" if body.url else "document",
         signal_keywords=profile.signal_keywords,
         anti_keywords=profile.anti_keywords,
+        icp=icp_text,
+        seller_mirror=seller_mirror_text,
         is_active=True,
     )
     db.add(version)
@@ -79,10 +97,21 @@ async def extract_profile(
 
     await db.flush()
 
-    # Store pgvector embedding via parameterized raw SQL
+    # Store pgvector embeddings via parameterized raw SQL (single round-trip)
     await db.execute(
-        text("UPDATE capability_profile_versions SET embedding = :emb WHERE id = :id"),
-        {"emb": str(embedding), "id": str(version.id)}
+        text(
+            "UPDATE capability_profile_versions "
+            "SET embedding = :emb, "
+            "    icp_embedding = :icp_emb, "
+            "    seller_mirror_embedding = :mirror_emb "
+            "WHERE id = :id"
+        ),
+        {
+            "emb": str(embedding),
+            "icp_emb": str(icp_embedding),
+            "mirror_emb": str(seller_mirror_embedding),
+            "id": str(version.id),
+        },
     )
 
     await db.commit()
@@ -92,4 +121,6 @@ async def extract_profile(
         capability_summary=profile.capability_summary,
         signal_keywords=profile.signal_keywords,
         version=version_number,
+        icp=icp_text,
+        seller_mirror=seller_mirror_text,
     )

--- a/backend/app/routers/profile.py
+++ b/backend/app/routers/profile.py
@@ -30,6 +30,11 @@ class ProfileExtractResponse(BaseModel):
     seller_mirror: str
 
 
+class UpdateIcpRequest(BaseModel):
+    icp: str | None = None
+    seller_mirror: str | None = None
+
+
 @router.post("/extract", response_model=ProfileExtractResponse)
 async def extract_profile(
     body: ProfileExtractRequest,
@@ -124,3 +129,68 @@ async def extract_profile(
         icp=icp_text,
         seller_mirror=seller_mirror_text,
     )
+
+
+@router.post("/update-icp")
+async def update_icp(
+    body: UpdateIcpRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    emb: EmbeddingProvider = Depends(get_embedding_provider),
+):
+    """Update the active CapabilityProfileVersion's ICP and/or seller_mirror text.
+
+    Re-embeds whichever fields are provided. At least one field must be present.
+    The active version is identified by workspace_id + is_active=True.
+    """
+    if not body.icp and not body.seller_mirror:
+        raise HTTPException(status_code=400, detail="Provide icp and/or seller_mirror")
+
+    # Resolve the active version id first
+    id_result = await db.execute(
+        select(CapabilityProfileVersion.id)
+        .where(CapabilityProfileVersion.workspace_id == current_user.workspace_id)
+        .where(CapabilityProfileVersion.is_active.is_(True))
+    )
+    version_id = id_result.scalar()
+    if version_id is None:
+        raise HTTPException(
+            status_code=404, detail="No active capability profile found"
+        )
+
+    # Update text fields via ORM (no vector columns here)
+    text_fields: dict = {}
+    if body.icp:
+        text_fields["icp"] = body.icp
+    if body.seller_mirror:
+        text_fields["seller_mirror"] = body.seller_mirror
+
+    await db.execute(
+        update(CapabilityProfileVersion)
+        .where(CapabilityProfileVersion.id == version_id)
+        .values(**text_fields)
+    )
+
+    # Re-embed via parameterized raw SQL (same pattern as /profile/extract)
+    set_clauses = []
+    params: dict = {"id": str(version_id)}
+    if body.icp:
+        icp_embedding = await emb.embed(body.icp)
+        set_clauses.append("icp_embedding = :icp_emb")
+        params["icp_emb"] = str(icp_embedding)
+    if body.seller_mirror:
+        seller_mirror_embedding = await emb.embed(body.seller_mirror)
+        set_clauses.append("seller_mirror_embedding = :mirror_emb")
+        params["mirror_emb"] = str(seller_mirror_embedding)
+
+    await db.execute(
+        text(
+            "UPDATE capability_profile_versions SET "
+            + ", ".join(set_clauses)
+            + " WHERE id = :id"
+        ),
+        params,
+    )
+
+    await db.commit()
+    return {"ok": True}

--- a/backend/app/routers/signals.py
+++ b/backend/app/routers/signals.py
@@ -25,6 +25,7 @@ from app.prompts.propose_signals import (
     SYSTEM_PROMPT,
     build_user_message,
 )
+from app.prompts import log_prompt_call
 
 router = APIRouter(prefix="/workspace/signals", tags=["signals"])
 
@@ -90,6 +91,13 @@ async def propose_signals(
     db.add(event)
     await db.commit()
     await db.refresh(event)
+
+    log_prompt_call(
+        feature="propose_signals",
+        prompt_version=PROMPT_VERSION,
+        model=OPENAI_MODEL_EXPENSIVE,
+        workspace_id=str(current_user.workspace_id),
+    )
 
     return ProposeSignalsResponse(
         proposal_event_id=event.id,

--- a/backend/app/services/fit_scorer.py
+++ b/backend/app/services/fit_scorer.py
@@ -1,0 +1,77 @@
+"""Fit × Intent hybrid scoring — Phase 2.6.
+
+Pure functions. No DB, no LLM, no async. Import-safe from workers and scripts.
+
+Design reference: docs/phase-2-6/design.md §3.2, §3.5.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Sequence
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity in [-1, 1]. Returns 0.0 if either vector is zero."""
+    if len(a) != len(b):
+        raise ValueError(f"dimension mismatch: {len(a)} vs {len(b)}")
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def compute_fit_score(
+    icp_embedding: Sequence[float],
+    seller_mirror_embedding: Sequence[float],
+    connection_embedding: Sequence[float],
+    lambda_: float,
+) -> float:
+    """fit_score = max(0, cos(ICP, conn) - λ·cos(seller_mirror, conn)).
+
+    Floored at 0: anti-ICP connections (raw < 0) get suppressed to 0, not
+    ranked negatively. Multiplying a negative fit by a positive intent
+    would invert ordering — not the intended behavior.
+
+    Raises ValueError on negative lambda_ or mismatched dimensions.
+    """
+    if lambda_ < 0:
+        raise ValueError(f"lambda_ must be non-negative, got {lambda_}")
+    if not (
+        len(icp_embedding) == len(seller_mirror_embedding) == len(connection_embedding)
+    ):
+        raise ValueError("all three embeddings must share dimension")
+
+    icp_cos = cosine_similarity(icp_embedding, connection_embedding)
+    mirror_cos = cosine_similarity(seller_mirror_embedding, connection_embedding)
+    raw = icp_cos - lambda_ * mirror_cos
+    return max(0.0, raw)
+
+
+def compute_intent_score(
+    relevance_score: float,
+    posted_at: datetime,
+    *,
+    now: datetime | None = None,
+) -> float:
+    """intent_score = 0.7·relevance + 0.3·timing. No relationship axis.
+
+    Relationship moves to the dashboard degree filter per design §3.5.
+    Timing decays linearly to 0 over 24 hours.
+    """
+    now = now or datetime.now(timezone.utc)
+    # Ensure posted_at is timezone-aware
+    if posted_at.tzinfo is None:
+        posted_at = posted_at.replace(tzinfo=timezone.utc)
+    hours_old = max(0.0, (now - posted_at).total_seconds() / 3600.0)
+    timing = max(0.0, 1.0 - hours_old / 24.0)
+    relevance = max(0.0, min(1.0, relevance_score))
+    return max(0.0, min(1.0, 0.7 * relevance + 0.3 * timing))
+
+
+def compute_hybrid_score(fit_score: float, intent_score: float) -> float:
+    """final_score = fit_score × intent_score, clamped to [0, 1]."""
+    return max(0.0, min(1.0, fit_score * intent_score))

--- a/backend/app/services/fit_scorer.py
+++ b/backend/app/services/fit_scorer.py
@@ -13,9 +13,15 @@ from typing import Sequence
 
 
 def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
-    """Cosine similarity in [-1, 1]. Returns 0.0 if either vector is zero."""
+    """Cosine similarity in [-1, 1]. Returns 0.0 if either vector is zero.
+
+    Pure-Python implementation — acceptable for the scoring layer where
+    this runs once per post-connection pair at pipeline time. If a future
+    caller batches thousands of pairs (e.g. a bulk re-embedding job),
+    migrate to numpy or defer to pgvector's `<=>` operator at the DB layer.
+    """
     if len(a) != len(b):
-        raise ValueError(f"dimension mismatch: {len(a)} vs {len(b)}")
+        raise ValueError(f"[fit_scorer] dimension mismatch: a={len(a)}, b={len(b)}")
     dot = sum(x * y for x, y in zip(a, b))
     na = math.sqrt(sum(x * x for x in a))
     nb = math.sqrt(sum(y * y for y in b))
@@ -43,7 +49,12 @@ def compute_fit_score(
     if not (
         len(icp_embedding) == len(seller_mirror_embedding) == len(connection_embedding)
     ):
-        raise ValueError("all three embeddings must share dimension")
+        raise ValueError(
+            f"[fit_scorer] embedding dimensions must match: "
+            f"icp={len(icp_embedding)}, "
+            f"mirror={len(seller_mirror_embedding)}, "
+            f"conn={len(connection_embedding)}"
+        )
 
     icp_cos = cosine_similarity(icp_embedding, connection_embedding)
     mirror_cos = cosine_similarity(seller_mirror_embedding, connection_embedding)

--- a/backend/app/services/profile_extractor.py
+++ b/backend/app/services/profile_extractor.py
@@ -3,6 +3,7 @@ import httpx
 from dataclasses import dataclass
 from app.config import OPENAI_MODEL_EXPENSIVE
 from app.services.llm import llm_client, LLMProvider
+from app.prompts import extract_icp_and_seller_mirror as icp_prompt
 
 PROFILE_EXTRACTION_PROMPT = """
 Analyze this company's website/document to build a sales intelligence capability profile.
@@ -44,6 +45,7 @@ async def fetch_url_content(url: str) -> str:
         resp = await client.get(url, headers={"User-Agent": "Mozilla/5.0"})
         resp.raise_for_status()
         from bs4 import BeautifulSoup
+
         soup = BeautifulSoup(resp.text, "html.parser")
         for tag in soup(["script", "style", "nav", "footer"]):
             tag.decompose()
@@ -81,3 +83,36 @@ async def extract_capability_profile(
 
     data = json.loads(raw)
     return CapabilityProfile(**data)
+
+
+async def extract_icp_and_seller_mirror(
+    *,
+    source_text: str,
+    llm_override=None,
+) -> tuple[str, str]:
+    """Call the ICP+seller_mirror prompt. Returns (icp, seller_mirror) strings.
+
+    Parse JSON, minimal schema check. Raises ValueError on malformed output.
+    """
+    from app.services.llm import get_llm_client
+
+    llm = llm_override or get_llm_client()
+    user_msg = icp_prompt.build_user_message(source_text=source_text)
+
+    raw = await llm.complete(
+        prompt=user_msg,
+        system=icp_prompt.SYSTEM_PROMPT,
+        model=OPENAI_MODEL_EXPENSIVE,
+        max_tokens=1200,
+    )
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"[profile_extractor] ICP prompt returned non-JSON: {e}. Raw: {raw[:200]}"
+        )
+    if "icp" not in parsed or "seller_mirror" not in parsed:
+        raise ValueError(
+            f"[profile_extractor] ICP response missing required keys. Got: {list(parsed.keys())}"
+        )
+    return parsed["icp"], parsed["seller_mirror"]

--- a/backend/app/services/profile_extractor.py
+++ b/backend/app/services/profile_extractor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from app.config import OPENAI_MODEL_EXPENSIVE
 from app.services.llm import llm_client, LLMProvider
 from app.prompts import extract_icp_and_seller_mirror as icp_prompt
+from app.prompts import log_prompt_call
 
 PROFILE_EXTRACTION_PROMPT = """
 Analyze this company's website/document to build a sales intelligence capability profile.
@@ -115,4 +116,9 @@ async def extract_icp_and_seller_mirror(
         raise ValueError(
             f"[profile_extractor] ICP response missing required keys. Got: {list(parsed.keys())}"
         )
+    log_prompt_call(
+        feature="extract_icp_and_seller_mirror",
+        prompt_version=icp_prompt.PROMPT_VERSION,
+        model=OPENAI_MODEL_EXPENSIVE,
+    )
     return parsed["icp"], parsed["seller_mirror"]

--- a/backend/app/workers/pipeline.py
+++ b/backend/app/workers/pipeline.py
@@ -356,12 +356,17 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
             )
 
         # Stage 10: Create alert
+        # In the hybrid path, relationship_score is not used — the degree
+        # filter lives on the dashboard.  Store NULL so formatters can omit
+        # the field instead of rendering a misleading "Relationship: 0%".
         alert = Alert(
             workspace_id=workspace_id,
             post_id=post_id,
             connection_id=post.connection_id,
             relevance_score=scoring.relevance_score,
-            relationship_score=scoring.relationship_score,
+            relationship_score=None
+            if workspace.use_hybrid_scoring
+            else scoring.relationship_score,
             timing_score=scoring.timing_score,
             combined_score=scoring.combined_score,
             priority=scoring.priority.value,

--- a/backend/app/workers/pipeline.py
+++ b/backend/app/workers/pipeline.py
@@ -62,7 +62,12 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
     from app.services.matcher import cosine_similarity
     from app.services.ring1_matcher import match_post_to_ring1_signals
     from app.services.ring2_matcher import match_post_embedding_to_ring2_signals
-    from app.services.scorer import compute_combined_score
+    from app.services.scorer import compute_combined_score, ScoringResult, Priority
+    from app.services.fit_scorer import (
+        compute_fit_score,
+        compute_intent_score,
+        compute_hybrid_score,
+    )
     from app.services.context_generator import generate_alert_context
     from app.services.keyword_filter import DEFAULT_BLOCKLIST
     from app.delivery.router import DeliveryRouter
@@ -199,13 +204,81 @@ async def _run_pipeline(post_id: UUID, workspace_id: UUID):
             await engine.dispose()
             return
 
-        scoring = compute_combined_score(
-            relevance_score=relevance_score,
-            connection=connection,
-            posted_at=post.posted_at or post.ingested_at,
-            weights=workspace.scoring_weights,
-            keyword_match_strength=keyword_match_strength,
-        )
+        if (
+            workspace.use_hybrid_scoring
+            and profile.icp_embedding is not None
+            and profile.seller_mirror_embedding is not None
+        ):
+            # Hybrid path. Populate connection.fit_score on first encounter.
+            if connection.fit_score is None:
+                text_for_embed = (
+                    f"{connection.headline or ''} {connection.company or ''}".strip()
+                )
+                if text_for_embed:
+                    conn_emb = await embedding_provider.embed(text_for_embed)
+                    # profile.icp_embedding and .seller_mirror_embedding come back as
+                    # pgvector objects; cast via list() so the fit_scorer sees Sequence[float].
+                    connection.fit_score = compute_fit_score(
+                        icp_embedding=list(profile.icp_embedding),
+                        seller_mirror_embedding=list(profile.seller_mirror_embedding),
+                        connection_embedding=conn_emb,
+                        lambda_=0.3,  # hardcoded; replace with workspace.hybrid_lambda after Task 9 calibration
+                    )
+                else:
+                    connection.fit_score = 0.0
+                await db.flush()
+
+            intent = compute_intent_score(
+                relevance_score=relevance_score,
+                posted_at=post.posted_at or post.ingested_at,
+            )
+            final = compute_hybrid_score(
+                fit_score=connection.fit_score,
+                intent_score=intent,
+            )
+
+            # Derive priority from the hybrid final score using the same
+            # thresholds as legacy scoring (0.80 high, 0.55 medium).
+            if final >= 0.80:
+                priority = Priority.HIGH
+            elif final >= 0.55:
+                priority = Priority.MEDIUM
+            else:
+                priority = Priority.LOW
+
+            # Timing is already folded into `intent`; surface the raw component
+            # for the legacy DB columns so dashboards/debugging still work.
+            posted = post.posted_at or post.ingested_at
+            if posted.tzinfo is None:
+                posted = posted.replace(tzinfo=timezone.utc)
+            hours_old = max(
+                0.0, (datetime.now(timezone.utc) - posted).total_seconds() / 3600.0
+            )
+            timing_component = max(0.0, 1.0 - hours_old / 24.0)
+
+            scoring = ScoringResult(
+                relevance_score=relevance_score,
+                relationship_score=0.0,  # not used in hybrid; degree filter lives on dashboard
+                timing_score=timing_component,
+                combined_score=final,
+                priority=priority,
+            )
+        else:
+            if workspace.use_hybrid_scoring:
+                logger.warning(
+                    "[pipeline] use_hybrid_scoring=True but ICP/seller_mirror embeddings missing "
+                    "for workspace_id=%s profile_id=%s — falling back to legacy scorer. "
+                    "Run /profile/extract then scripts/backfill_fit_scores.py to populate.",
+                    workspace_id,
+                    profile.id,
+                )
+            scoring = compute_combined_score(
+                relevance_score=relevance_score,
+                connection=connection,
+                posted_at=post.posted_at or post.ingested_at,
+                weights=workspace.scoring_weights,
+                keyword_match_strength=keyword_match_strength,
+            )
 
         threshold = workspace.matching_threshold or 0.72
         if scoring.combined_score < threshold:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.24.0",
     "httpx>=0.27.0",
+    "jsonschema>=4.23.0",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/scripts/backfill_fit_scores.py
+++ b/backend/scripts/backfill_fit_scores.py
@@ -35,6 +35,18 @@ from app.services.embedding import get_embedding_provider  # noqa: E402
 from app.services.fit_scorer import compute_fit_score  # noqa: E402
 
 
+# Commit every COMMIT_BATCH connections so a mid-loop embedding failure
+# doesn't lose all prior progress. At 10k connections a transient 429/503
+# otherwise rolls back the entire session.
+COMMIT_BATCH = 100
+
+# Rough cost estimate for operator-facing logging. text-embedding-3-small
+# is billed per input token; we approximate at ~50 tokens per connection
+# (headline + company) × $0.02 / 1M tokens = ~$0.000001 per call. The
+# constant may drift with OpenAI pricing; this is a signal, not a budget.
+_EMBED_COST_PER_CALL_USD = 0.000001
+
+
 async def run(
     db, workspace_id: UUID, *, recompute_all: bool = False, lambda_: float = 0.3
 ) -> dict:
@@ -65,28 +77,33 @@ async def run(
     icp_emb = list(profile.icp_embedding)
     mirror_emb = list(profile.seller_mirror_embedding)
 
+    total = len(connections)
     updated = 0
     skipped_empty = 0
-    for conn in connections:
+    for i, conn in enumerate(connections, 1):
         text = f"{conn.headline or ''} {conn.company or ''}".strip()
         if not text:
             conn.fit_score = 0.0
             skipped_empty += 1
-            continue
-        conn_emb = await emb.embed(text)
-        conn.fit_score = compute_fit_score(
-            icp_embedding=icp_emb,
-            seller_mirror_embedding=mirror_emb,
-            connection_embedding=conn_emb,
-            lambda_=lambda_,
-        )
-        updated += 1
+        else:
+            conn_emb = await emb.embed(text)
+            conn.fit_score = compute_fit_score(
+                icp_embedding=icp_emb,
+                seller_mirror_embedding=mirror_emb,
+                connection_embedding=conn_emb,
+                lambda_=lambda_,
+            )
+            updated += 1
+        if i % COMMIT_BATCH == 0:
+            await db.commit()
+            print(f"[backfill_fit_scores] progress {i}/{total}")
 
     await db.commit()
     return {
         "updated": updated,
         "skipped_empty": skipped_empty,
-        "total": len(connections),
+        "total": total,
+        "estimated_cost_usd": round(updated * _EMBED_COST_PER_CALL_USD, 6),
     }
 
 
@@ -107,16 +124,20 @@ async def _main():
     engine = create_async_engine(settings.database_url)
     Session = async_sessionmaker(engine, expire_on_commit=False)
 
-    async with Session() as db:
-        summary = await run(
-            db,
-            workspace_id=args.workspace_id,
-            recompute_all=args.recompute_all,
-            lambda_=args.lambda_,
-        )
-        print(f"[backfill_fit_scores] {summary}")
-
-    await engine.dispose()
+    try:
+        async with Session() as db:
+            summary = await run(
+                db,
+                workspace_id=args.workspace_id,
+                recompute_all=args.recompute_all,
+                lambda_=args.lambda_,
+            )
+            print(f"[backfill_fit_scores] done: {summary}")
+    except (ValueError, RuntimeError) as e:
+        print(f"[backfill_fit_scores] Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        await engine.dispose()
 
 
 if __name__ == "__main__":

--- a/backend/scripts/backfill_fit_scores.py
+++ b/backend/scripts/backfill_fit_scores.py
@@ -1,0 +1,123 @@
+"""One-shot script: populate connection.fit_score for a workspace.
+
+Loads the active CapabilityProfileVersion for the workspace (must have
+icp_embedding + seller_mirror_embedding). For each connection in the workspace:
+  1. Embed headline + company.
+  2. Compute fit_score via fit_scorer.
+  3. Persist.
+
+Usage inside api container:
+  python scripts/backfill_fit_scores.py --workspace-id <uuid>
+  python scripts/backfill_fit_scores.py --workspace-id <uuid> --recompute-all
+
+The --recompute-all flag forces re-embed of every connection, overwriting any
+existing fit_score. Useful after an ICP change.
+"""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from uuid import UUID
+
+# Allow direct invocation via `python scripts/backfill_fit_scores.py ...` by
+# inserting the backend root on sys.path. Matches the sibling pattern in
+# calibrate_matching.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import select  # noqa: E402
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine  # noqa: E402
+
+from app.config import get_settings  # noqa: E402
+from app.models.connection import Connection  # noqa: E402
+from app.models.workspace import CapabilityProfileVersion  # noqa: E402
+from app.services.embedding import get_embedding_provider  # noqa: E402
+from app.services.fit_scorer import compute_fit_score  # noqa: E402
+
+
+async def run(
+    db, workspace_id: UUID, *, recompute_all: bool = False, lambda_: float = 0.3
+) -> dict:
+    profile = (
+        await db.execute(
+            select(CapabilityProfileVersion)
+            .where(CapabilityProfileVersion.workspace_id == workspace_id)
+            .where(CapabilityProfileVersion.is_active.is_(True))
+        )
+    ).scalar_one_or_none()
+    if profile is None:
+        raise RuntimeError(
+            f"No active capability_profile_version for workspace {workspace_id}"
+        )
+    if profile.icp_embedding is None or profile.seller_mirror_embedding is None:
+        raise RuntimeError(
+            f"Workspace {workspace_id} active profile has no ICP/seller_mirror embeddings. "
+            "Run /profile/extract first."
+        )
+
+    emb = get_embedding_provider()
+
+    q = select(Connection).where(Connection.workspace_id == workspace_id)
+    if not recompute_all:
+        q = q.where(Connection.fit_score.is_(None))
+    connections = (await db.execute(q)).scalars().all()
+
+    icp_emb = list(profile.icp_embedding)
+    mirror_emb = list(profile.seller_mirror_embedding)
+
+    updated = 0
+    skipped_empty = 0
+    for conn in connections:
+        text = f"{conn.headline or ''} {conn.company or ''}".strip()
+        if not text:
+            conn.fit_score = 0.0
+            skipped_empty += 1
+            continue
+        conn_emb = await emb.embed(text)
+        conn.fit_score = compute_fit_score(
+            icp_embedding=icp_emb,
+            seller_mirror_embedding=mirror_emb,
+            connection_embedding=conn_emb,
+            lambda_=lambda_,
+        )
+        updated += 1
+
+    await db.commit()
+    return {
+        "updated": updated,
+        "skipped_empty": skipped_empty,
+        "total": len(connections),
+    }
+
+
+async def _main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace-id", type=UUID, required=True)
+    parser.add_argument("--recompute-all", action="store_true")
+    parser.add_argument(
+        "--lambda",
+        type=float,
+        default=0.3,
+        dest="lambda_",
+        help="Subtractive weight on seller_mirror term (default 0.3)",
+    )
+    args = parser.parse_args()
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with Session() as db:
+        summary = await run(
+            db,
+            workspace_id=args.workspace_id,
+            recompute_all=args.recompute_all,
+            lambda_=args.lambda_,
+        )
+        print(f"[backfill_fit_scores] {summary}")
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/backend/scripts/calibrate_matching.py
+++ b/backend/scripts/calibrate_matching.py
@@ -269,6 +269,46 @@ def compute_metrics_at_threshold(
     }
 
 
+def precision_at_k(ranked: list[tuple[float, bool, bool]], k: int = 5) -> float:
+    """ranked: list of (score, is_match, is_competitor) sorted by score desc.
+    Returns matches_in_top_k / len(top_k)."""
+    top = ranked[:k]
+    if not top:
+        return 0.0
+    matches = sum(1 for _score, is_match, _comp in top if is_match)
+    return matches / len(top)
+
+
+def recall_at_k(ranked: list[tuple[float, bool, bool]], k: int = 5) -> float:
+    """Recall at k against all true matches in the dataset (not just top-k)."""
+    total_true = sum(1 for _score, is_match, _comp in ranked if is_match)
+    if total_true == 0:
+        return 0.0
+    top_true = sum(1 for _score, is_match, _comp in ranked[:k] if is_match)
+    return top_true / total_true
+
+
+def competitor_count_in_top_k(
+    ranked: list[tuple[float, bool, bool]], k: int = 5
+) -> int:
+    """Count competitor-flagged posts in top-k."""
+    return sum(1 for _score, _is_match, is_comp in ranked[:k] if is_comp)
+
+
+def load_competitor_set(competitors_path: Path | None) -> set[str]:
+    """Load a set of connection UUID strings from a newline-separated file.
+    Returns empty set if path is None. Ignores blank lines and # comments."""
+    if competitors_path is None:
+        return set()
+    out: set[str] = set()
+    for line in competitors_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.add(line.lower())
+    return out
+
+
 def print_distribution(cosines: list[float], labels: list[bool]) -> None:
     match_cos = sorted([c for c, lb in zip(cosines, labels) if lb])
     nonmatch_cos = sorted([c for c, lb in zip(cosines, labels) if not lb])
@@ -416,6 +456,161 @@ async def cmd_analyze(workspace_id: UUID, labels_path: Path) -> None:
     )
 
 
+# ---------- Phase 3 — analyze-hybrid (λ sweep) ---------------------------
+
+
+async def cmd_analyze_hybrid(args) -> None:
+    from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+    from sqlalchemy import select
+    from app.config import get_settings
+    from app.models.workspace import CapabilityProfileVersion
+    from app.models.connection import Connection
+    from app.models.post import Post
+    from app.services.fit_scorer import (
+        compute_fit_score,
+        compute_intent_score,
+        compute_hybrid_score,
+        cosine_similarity,
+    )
+    from app.services.embedding import embedding_provider
+
+    labels_map = parse_labels(args.labels)  # {post_id: is_match}
+    if not labels_map:
+        print(f"[calibrate-hybrid] no labels parsed from {args.labels}")
+        sys.exit(1)
+
+    lambdas = [float(x) for x in args.lambdas.split(",")]
+    competitor_ids = load_competitor_set(args.competitors)
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with Session() as db:
+        profile = (
+            await db.execute(
+                select(CapabilityProfileVersion)
+                .where(CapabilityProfileVersion.workspace_id == args.workspace_id)
+                .where(CapabilityProfileVersion.is_active.is_(True))
+            )
+        ).scalar_one_or_none()
+        if profile is None:
+            print(
+                f"[calibrate-hybrid] no active capability_profile_version for {args.workspace_id}"
+            )
+            sys.exit(1)
+        if profile.icp_embedding is None or profile.seller_mirror_embedding is None:
+            print(
+                "[calibrate-hybrid] active profile has no ICP/seller_mirror embeddings. "
+                "Run /profile/extract first."
+            )
+            sys.exit(1)
+
+        icp_emb = list(profile.icp_embedding)
+        mirror_emb = list(profile.seller_mirror_embedding)
+        cap_emb = list(profile.embedding) if profile.embedding is not None else None
+
+        # Fetch each labeled post joined with its connection + embedding text.
+        post_rows = (
+            await db.execute(
+                select(Post, Connection)
+                .join(Connection, Post.connection_id == Connection.id)
+                .where(Post.id.in_([UUID(pid) for pid in labels_map.keys()]))
+            )
+        ).all()
+
+        # Fetch post embeddings via raw SQL (pgvector cast to text, then json-parse).
+        import json
+        from sqlalchemy import text as sql_text
+
+        post_emb_rows = (
+            await db.execute(
+                sql_text(
+                    "SELECT id::text, embedding::text FROM posts WHERE id = ANY(:ids)"
+                ),
+                {"ids": list(labels_map.keys())},
+            )
+        ).all()
+        post_embs = {
+            pid: json.loads(emb_str) if emb_str else None
+            for pid, emb_str in post_emb_rows
+        }
+
+        # Embed each connection's headline+company exactly once.
+        conn_embs: dict[str, list[float]] = {}
+        for _post, conn in post_rows:
+            cid = str(conn.id)
+            if cid in conn_embs:
+                continue
+            text_for_embed = f"{conn.headline or ''} {conn.company or ''}".strip()
+            conn_embs[cid] = (
+                await embedding_provider.embed(text_for_embed)
+                if text_for_embed
+                else [0.0] * 1536
+            )
+
+        print(f"\n{'λ':>5} | {'P@5':>5} | {'R@5':>5} | {'comp@5':>6} | DoD?")
+        print("-" * 45)
+
+        best_lambda = None
+        for lam in lambdas:
+            ranked: list[tuple[float, bool, bool]] = []
+            top5_preview: list[
+                tuple[float, str, str, str]
+            ] = []  # (score, post_id, headline, company)
+
+            for post, conn in post_rows:
+                pid = str(post.id)
+                if pid not in labels_map:
+                    continue
+                post_emb = post_embs.get(pid)
+                if post_emb is None or cap_emb is None:
+                    continue
+                fit = compute_fit_score(
+                    icp_embedding=icp_emb,
+                    seller_mirror_embedding=mirror_emb,
+                    connection_embedding=conn_embs[str(conn.id)],
+                    lambda_=lam,
+                )
+                relevance = cosine_similarity(cap_emb, post_emb)
+                intent = compute_intent_score(
+                    relevance_score=relevance,
+                    posted_at=post.posted_at or post.ingested_at,
+                )
+                final = compute_hybrid_score(fit, intent)
+
+                is_match = labels_map[pid]
+                is_competitor = str(conn.id).lower() in competitor_ids
+                ranked.append((final, is_match, is_competitor))
+                top5_preview.append(
+                    (final, pid, conn.headline or "", conn.company or "")
+                )
+
+            ranked.sort(key=lambda x: -x[0])
+            top5_preview.sort(key=lambda x: -x[0])
+
+            p5 = precision_at_k(ranked, k=5)
+            r5 = recall_at_k(ranked, k=5)
+            comp5 = competitor_count_in_top_k(ranked, k=5)
+            dod = "YES" if (p5 >= 0.6 and r5 >= 0.5 and comp5 == 0) else "no"
+            print(f"{lam:>5.2f} | {p5:>5.2f} | {r5:>5.2f} | {comp5:>6d} | {dod}")
+
+            if dod == "YES" and best_lambda is None:
+                best_lambda = lam
+                # Show top-5 for visual competitor check at the winning λ
+                print(f"\n  top-5 at λ={lam}:")
+                for score, pid, headline, company in top5_preview[:5]:
+                    print(f"    {score:.3f}  {pid}  {headline[:60]}  @ {company[:40]}")
+
+        if best_lambda is None:
+            print(
+                "\n[calibrate-hybrid] no λ satisfied DoD (P@5 ≥ 0.6, R@5 ≥ 0.5, zero top-5 competitors)."
+            )
+            print("See design.md §5 step 8 for diagnostic paths.")
+
+    await engine.dispose()
+
+
 # ---------- main ---------------------------------------------------------
 
 
@@ -431,11 +626,39 @@ def main() -> None:
     an.add_argument("--workspace-id", type=UUID, required=True)
     an.add_argument("--labels", type=Path, required=True)
 
+    hy = subparsers.add_parser(
+        "analyze-hybrid", help="Sweep λ for Phase 2.6 hybrid scoring"
+    )
+    hy.add_argument("--workspace-id", type=UUID, required=True)
+    hy.add_argument(
+        "--labels",
+        type=Path,
+        required=True,
+        help="Labeled dataset file (same format as the existing analyze input)",
+    )
+    hy.add_argument(
+        "--lambdas",
+        type=str,
+        default="0.0,0.1,0.2,0.3,0.5,0.7,1.0",
+        help="Comma-separated λ values to sweep",
+    )
+    hy.add_argument(
+        "--competitors",
+        type=Path,
+        default=None,
+        help=(
+            "Optional: file with newline-separated connection UUIDs known to be competitors. "
+            "If provided, analyzer reports top-5 competitor leakage automatically."
+        ),
+    )
+
     args = parser.parse_args()
     if args.cmd == "export":
         asyncio.run(cmd_export(args.workspace_id, args.out))
     elif args.cmd == "analyze":
         asyncio.run(cmd_analyze(args.workspace_id, args.labels))
+    elif args.cmd == "analyze-hybrid":
+        asyncio.run(cmd_analyze_hybrid(args))
 
 
 if __name__ == "__main__":

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -85,3 +85,42 @@ async def client(db_session):
     ) as c:
         yield c
     app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def workspace_id(db_session):
+    """Create a test workspace and return its UUID."""
+    from app.models.workspace import Workspace
+
+    ws = Workspace(name="Test WS", plan_tier="starter")
+    db_session.add(ws)
+    await db_session.flush()
+    return ws.id
+
+
+@pytest_asyncio.fixture
+async def auth_headers(workspace_id, db_session):
+    """Install a dependency override for get_current_user that returns a fake
+    User bound to `workspace_id`, and return an empty headers dict.
+
+    Tests do: `await client.post('/x', json=..., headers=auth_headers)`.
+    The override is cleared by the `client` fixture's `app.dependency_overrides.clear()`
+    at teardown, so no leak between tests.
+    """
+    from app.main import app
+    from app.routers.auth import get_current_user
+    from app.models.user import User
+
+    user = User(
+        email="test@example.com",
+        hashed_password="x",  # not used — auth is overridden
+        workspace_id=workspace_id,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    async def _override():
+        return user
+
+    app.dependency_overrides[get_current_user] = _override
+    return {}  # empty dict; override handles auth, no Bearer token needed

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -88,6 +88,102 @@ async def client(db_session):
 
 
 @pytest_asyncio.fixture
+async def pipeline_setup(db_session):
+    """Factory: returns an async callable that creates a workspace + user +
+    capability profile (with ICP/seller_mirror embeddings) + connection + post.
+    Returns (workspace_id, post_id, connection_id)."""
+    from datetime import datetime, timezone
+    from uuid import uuid4
+    from sqlalchemy import text as sql_text
+
+    async def _factory(*, use_hybrid: bool):
+        from app.models.workspace import Workspace, CapabilityProfileVersion
+        from app.models.user import User
+        from app.models.connection import Connection
+        from app.models.post import Post
+
+        ws = Workspace(
+            name="PipelineTestWS",
+            plan_tier="starter",
+            matching_threshold=0.1,  # low so scores pass through
+            use_hybrid_scoring=use_hybrid,
+        )
+        db_session.add(ws)
+        await db_session.flush()
+
+        user = User(
+            email=f"u-{uuid4()}@test",
+            hashed_password="x",
+            workspace_id=ws.id,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        profile = CapabilityProfileVersion(
+            workspace_id=ws.id,
+            version=1,
+            raw_text="Test capability: customer data platform for D2C brands.",
+            source="text",
+            signal_keywords=["cdp"],
+            anti_keywords=[],
+            icp="Marketing and growth leaders at D2C brands with >$1M ARR. Not competing martech vendors.",
+            seller_mirror="Founders, CEOs, CPOs at martech SaaS companies.",
+            is_active=True,
+        )
+        db_session.add(profile)
+        await db_session.flush()
+
+        # Populate the three pgvector columns via parameterized SQL.
+        fake_emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        await db_session.execute(
+            sql_text(
+                "UPDATE capability_profile_versions "
+                "SET embedding = CAST(:e AS vector), "
+                "    icp_embedding = CAST(:e AS vector), "
+                "    seller_mirror_embedding = CAST(:e AS vector) "
+                "WHERE id = :id"
+            ),
+            {"e": fake_emb, "id": str(profile.id)},
+        )
+
+        conn = Connection(
+            workspace_id=ws.id,
+            user_id=user.id,
+            linkedin_id=f"li-{uuid4()}",
+            name="Test Buyer",
+            headline="Head of Growth at Acme D2C",
+            company="Acme D2C",
+            degree=2,
+        )
+        db_session.add(conn)
+        await db_session.flush()
+
+        post = Post(
+            workspace_id=ws.id,
+            connection_id=conn.id,
+            linkedin_post_id=f"p-{uuid4()}",
+            content="Looking at customer data tooling for our D2C stack.",
+            post_type="post",
+            source="extension",
+            posted_at=datetime.now(timezone.utc),
+            ingested_at=datetime.now(timezone.utc),
+        )
+        db_session.add(post)
+        await db_session.flush()
+
+        # Populate post embedding.
+        await db_session.execute(
+            sql_text("UPDATE posts SET embedding = CAST(:e AS vector) WHERE id = :id"),
+            {"e": fake_emb, "id": str(post.id)},
+        )
+        await db_session.commit()
+
+        return ws.id, post.id, conn.id
+
+    return _factory
+
+
+@pytest_asyncio.fixture
 async def workspace_id(db_session):
     """Create a test workspace and return its UUID."""
     from app.models.workspace import Workspace

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -184,6 +184,135 @@ async def pipeline_setup(db_session):
 
 
 @pytest_asyncio.fixture
+async def workspace_with_icp(db_session):
+    """Workspace + active CapabilityProfileVersion with icp/seller_mirror embeddings populated.
+    Returns the workspace_id (UUID)."""
+    from uuid import uuid4
+    from sqlalchemy import text as sql_text
+    from app.models.workspace import Workspace, CapabilityProfileVersion
+    from app.models.user import User
+
+    ws = Workspace(name="BackfillTest", plan_tier="starter", use_hybrid_scoring=True)
+    db_session.add(ws)
+    await db_session.flush()
+
+    user = User(email=f"u-{uuid4()}@test", hashed_password="x", workspace_id=ws.id)
+    db_session.add(user)
+
+    profile = CapabilityProfileVersion(
+        workspace_id=ws.id,
+        version=1,
+        raw_text="...",
+        source="text",
+        signal_keywords=[],
+        anti_keywords=[],
+        icp="ICP text.",
+        seller_mirror="Seller mirror text.",
+        is_active=True,
+    )
+    db_session.add(profile)
+    await db_session.flush()
+
+    fake_emb = "[" + ",".join(["0.1"] * 1536) + "]"
+    await db_session.execute(
+        sql_text(
+            "UPDATE capability_profile_versions "
+            "SET embedding = CAST(:e AS vector), "
+            "    icp_embedding = CAST(:e AS vector), "
+            "    seller_mirror_embedding = CAST(:e AS vector) "
+            "WHERE id = :id"
+        ),
+        {"e": fake_emb, "id": str(profile.id)},
+    )
+    # Capture user_id before commit expires the ORM instance.
+    user_id = user.id
+    await db_session.commit()
+    # Stash user_id on a plain object so connection fixtures can reference it
+    # without re-fetching. This is a test-only pattern; production code never
+    # touches _test_user_id.
+    import types
+
+    result = types.SimpleNamespace(id=ws.id, _test_user_id=user_id)
+    return result
+
+
+async def _add_connection(
+    db, workspace_id, user_id, *, headline: str, company: str, fit_score=None
+):
+    from uuid import uuid4
+    from app.models.connection import Connection
+
+    conn = Connection(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        linkedin_id=f"li-{uuid4()}",
+        name="N",
+        headline=headline,
+        company=company,
+        degree=2,
+        fit_score=fit_score,
+    )
+    db.add(conn)
+    await db.flush()
+    return conn.id
+
+
+@pytest_asyncio.fixture
+async def seeded_connections(db_session, workspace_with_icp):
+    """3 connections in the workspace, all with fit_score=None."""
+    ids = []
+    for h, c in [
+        ("Head of Growth at Acme D2C", "Acme D2C"),
+        ("CMO", "Retail Co"),
+        ("VP Marketing", "BrandX"),
+    ]:
+        ids.append(
+            await _add_connection(
+                db_session,
+                workspace_with_icp.id,
+                workspace_with_icp._test_user_id,
+                headline=h,
+                company=c,
+            )
+        )
+    await db_session.commit()
+    return ids
+
+
+@pytest_asyncio.fixture
+async def seeded_connections_mixed(db_session, workspace_with_icp):
+    """Mixed: 2 connections without fit_score + 1 with fit_score=0.5 pre-populated."""
+    ids = [
+        await _add_connection(
+            db_session,
+            workspace_with_icp.id,
+            workspace_with_icp._test_user_id,
+            headline="CMO",
+            company="X",
+            fit_score=None,
+        ),
+        await _add_connection(
+            db_session,
+            workspace_with_icp.id,
+            workspace_with_icp._test_user_id,
+            headline="VP Growth",
+            company="Y",
+            fit_score=None,
+        ),
+        await _add_connection(
+            db_session,
+            workspace_with_icp.id,
+            workspace_with_icp._test_user_id,
+            headline="Founder",
+            company="Z",
+            fit_score=0.5,
+        ),
+    ]
+    await db_session.commit()
+    return ids
+
+
+@pytest_asyncio.fixture
 async def workspace_id(db_session):
     """Create a test workspace and return its UUID."""
     from app.models.workspace import Workspace

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,10 +1,20 @@
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient, ASGITransport
+from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from app.main import app
 from app.database import Base, get_db
 from app.config import get_settings
+
+
+@pytest.fixture
+def sync_engine():
+    """Synchronous engine for DDL introspection. Separate from the async test engine."""
+    url = get_settings().database_url.replace("+asyncpg", "")
+    engine = create_engine(url)
+    yield engine
+    engine.dispose()
 
 
 @pytest.fixture(autouse=True)
@@ -15,6 +25,7 @@ def _reset_provider_singletons():
     prior test's real client). Closes issue #22."""
     yield
     from app.services import embedding, llm
+
     embedding._provider = None
     llm._openai = None
     llm._groq = None
@@ -36,6 +47,7 @@ def _reset_provider_singletons():
 # it was removed as part of the Phase 2 Foundation pre-merge cleanup.
 # Configured via `pyproject.toml [tool.pytest.ini_options]`.
 
+
 @pytest_asyncio.fixture
 async def test_engine():
     # Swap only the trailing database name (not any earlier "/sonar" in credentials/host)
@@ -48,22 +60,28 @@ async def test_engine():
     yield engine
     await engine.dispose()
 
+
 @pytest_asyncio.fixture
 async def db_session(test_engine):
     TestSession = async_sessionmaker(test_engine, expire_on_commit=False)
     async with TestSession() as session:
         yield session
 
+
 @pytest_asyncio.fixture
 async def client(db_session):
     async def override_get_db():
         yield db_session
+
     app.dependency_overrides[get_db] = override_get_db
     # Reset slowapi counters per-test — ASGITransport reuses one client IP,
     # so without this any test hitting a rate-limited endpoint accumulates
     # counters that would leak into subsequent tests.
     from app.rate_limit import limiter
+
     limiter.reset()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
         yield c
     app.dependency_overrides.clear()

--- a/backend/tests/test_backfill_fit_scores.py
+++ b/backend/tests/test_backfill_fit_scores.py
@@ -1,0 +1,64 @@
+"""Integration test: backfill script populates fit_score for every connection."""
+
+import pytest
+from sqlalchemy import select
+
+from app.models.connection import Connection
+
+
+@pytest.mark.asyncio
+async def test_backfill_populates_fit_score_for_all_connections(
+    db_session,
+    workspace_with_icp,
+    seeded_connections,
+):
+    from scripts.backfill_fit_scores import run
+
+    # Override the embedding provider to avoid real OpenAI calls.
+    from app.services import embedding as emb_mod
+
+    class _FakeProvider:
+        async def embed(self, text: str) -> list[float]:
+            return [0.2] * 1536
+
+    emb_mod._provider = _FakeProvider()
+
+    summary = await run(db_session, workspace_id=workspace_with_icp.id)
+
+    assert summary["updated"] == 3
+    conns = (
+        (
+            await db_session.execute(
+                select(Connection).where(
+                    Connection.workspace_id == workspace_with_icp.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for c in conns:
+        assert c.fit_score is not None
+        assert 0.0 <= c.fit_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_connections_with_existing_fit_score(
+    db_session,
+    workspace_with_icp,
+    seeded_connections_mixed,
+):
+    """Default mode skips connections that already have a fit_score."""
+    from scripts.backfill_fit_scores import run
+    from app.services import embedding as emb_mod
+
+    class _FakeProvider:
+        async def embed(self, text: str) -> list[float]:
+            return [0.2] * 1536
+
+    emb_mod._provider = _FakeProvider()
+
+    summary = await run(
+        db_session, workspace_id=workspace_with_icp.id, recompute_all=False
+    )
+    assert summary["updated"] == 2  # the two with fit_score=None

--- a/backend/tests/test_calibrate_hybrid.py
+++ b/backend/tests/test_calibrate_hybrid.py
@@ -1,0 +1,55 @@
+"""Unit tests for the metrics helpers used by analyze-hybrid."""
+
+from scripts.calibrate_matching import (
+    precision_at_k,
+    recall_at_k,
+    competitor_count_in_top_k,
+)
+
+
+def test_precision_at_5_mixed_ranking():
+    # 3 of top-5 are true matches → 0.6
+    # Each item is (score, is_match, is_competitor).
+    ranked = [
+        (0.9, True, False),
+        (0.8, False, False),
+        (0.7, True, False),
+        (0.6, True, False),
+        (0.5, False, False),
+        (0.4, True, False),
+    ]
+    assert precision_at_k(ranked, k=5) == 0.6
+
+
+def test_precision_at_5_fewer_than_k():
+    ranked = [(0.9, True, False), (0.8, True, False)]
+    assert precision_at_k(ranked, k=5) == 1.0  # 2/2
+
+
+def test_recall_half_caught():
+    ranked = [
+        (0.9, True, False),
+        (0.8, False, False),
+        (0.7, True, False),
+        (0.6, False, False),
+        (0.5, True, False),
+        (0.4, True, False),
+    ]
+    # top-5 has 3 true matches; total true matches = 4 → 3/4 = 0.75
+    assert recall_at_k(ranked, k=5) == 0.75
+
+
+def test_competitor_count_in_top_5():
+    ranked = [
+        (0.9, True, False),
+        (0.85, False, True),
+        (0.8, False, True),
+        (0.7, True, False),
+        (0.6, False, False),
+    ]
+    assert competitor_count_in_top_k(ranked, k=5) == 2
+
+
+def test_competitor_count_zero_when_none_flagged():
+    ranked = [(0.9, True, False)] * 5
+    assert competitor_count_in_top_k(ranked, k=5) == 0

--- a/backend/tests/test_delivery_formatters_nullable_relationship.py
+++ b/backend/tests/test_delivery_formatters_nullable_relationship.py
@@ -1,0 +1,172 @@
+"""Delivery formatter: graceful handling of alert.relationship_score=None.
+
+When workspace.use_hybrid_scoring=True, the Alert row has
+relationship_score=None (issue #120 fix).  Each formatter must omit the
+relationship field rather than raise a TypeError or render "0%".
+
+These are pure unit tests — no DB, no network, no Docker I/O.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+
+from app.delivery.slack import _score_bar
+from app.delivery.telegram import _score_bar as tg_score_bar
+
+
+def _make_alert(relationship_score):
+    return SimpleNamespace(
+        id=uuid4(),
+        priority="high",
+        combined_score=0.85,
+        relevance_score=0.88,
+        relationship_score=relationship_score,
+        timing_score=0.82,
+        match_reason="They posted about buying intent.",
+        outreach_draft_a="Draft A.",
+        outreach_draft_b="Draft B.",
+        opportunity_type="service_need",
+        urgency_reason="Post is fresh.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slack
+# ---------------------------------------------------------------------------
+
+
+def _build_slack_blocks(alert):
+    """Invoke the block-building logic without making an HTTP call."""
+    from app.delivery.slack import PRIORITY_EMOJI
+
+    emoji = PRIORITY_EMOJI.get(alert.priority, "⚪")
+    blocks = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f"{emoji} {alert.priority.upper()} SIGNAL",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*Why it matches:*\n{alert.match_reason}",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "\n".join(
+                    filter(
+                        None,
+                        [
+                            f"Relevance: `{_score_bar(alert.relevance_score)}` {alert.relevance_score:.0%}",
+                            (
+                                f"Relationship: `{_score_bar(alert.relationship_score)}` {alert.relationship_score:.0%}"
+                                if alert.relationship_score is not None
+                                else None
+                            ),
+                            f"Timing: `{_score_bar(alert.timing_score)}` {alert.timing_score:.0%}",
+                        ],
+                    )
+                ),
+            },
+        },
+    ]
+    return blocks
+
+
+def test_slack_omits_relationship_when_none():
+    alert = _make_alert(relationship_score=None)
+    blocks = _build_slack_blocks(alert)
+    scores_block = blocks[2]["text"]["text"]
+    assert "Relationship" not in scores_block
+    assert "Relevance" in scores_block
+    assert "Timing" in scores_block
+
+
+def test_slack_includes_relationship_when_present():
+    alert = _make_alert(relationship_score=0.75)
+    blocks = _build_slack_blocks(alert)
+    scores_block = blocks[2]["text"]["text"]
+    assert "Relationship" in scores_block
+    assert "75%" in scores_block
+
+
+# ---------------------------------------------------------------------------
+# Telegram
+# ---------------------------------------------------------------------------
+
+
+def _build_telegram_text(alert):
+    from app.delivery.telegram import _escape_mdv2
+
+    relationship_line = (
+        f"📊 Relationship: `{tg_score_bar(alert.relationship_score)}` {alert.relationship_score:.0%}\n"
+        if alert.relationship_score is not None
+        else ""
+    )
+    text = (
+        f"🔴 *HIGH SIGNAL*\n\n"
+        f"🎯 *Why it matches:*\n{_escape_mdv2(alert.match_reason)}\n\n"
+        f"📊 Relevance: `{tg_score_bar(alert.relevance_score)}` {alert.relevance_score:.0%}\n"
+        f"{relationship_line}"
+        f"📊 Timing: `{tg_score_bar(alert.timing_score)}` {alert.timing_score:.0%}\n\n"
+        f"✉️ *Draft A \\(Direct\\):*\n_{_escape_mdv2(alert.outreach_draft_a)}_\n\n"
+        f"✉️ *Draft B \\(Question\\):*\n_{_escape_mdv2(alert.outreach_draft_b)}_"
+    )
+    return text
+
+
+def test_telegram_omits_relationship_when_none():
+    alert = _make_alert(relationship_score=None)
+    text = _build_telegram_text(alert)
+    assert "Relationship" not in text
+    assert "Relevance" in text
+    assert "Timing" in text
+
+
+def test_telegram_includes_relationship_when_present():
+    alert = _make_alert(relationship_score=0.60)
+    text = _build_telegram_text(alert)
+    assert "Relationship" in text
+    assert "60%" in text
+
+
+# ---------------------------------------------------------------------------
+# Email
+# ---------------------------------------------------------------------------
+
+
+def _build_email_html(alert):
+    relationship_segment = (
+        f"Relationship: {alert.relationship_score:.0%} | "
+        if alert.relationship_score is not None
+        else ""
+    )
+    html = (
+        f"Scores — Relevance: {alert.relevance_score:.0%} | "
+        f"{relationship_segment}Timing: {alert.timing_score:.0%} | "
+        f"Combined: {alert.combined_score:.0%}"
+    )
+    return html
+
+
+def test_email_omits_relationship_when_none():
+    alert = _make_alert(relationship_score=None)
+    html = _build_email_html(alert)
+    assert "Relationship" not in html
+    assert "Relevance" in html
+    assert "Timing" in html
+    assert "Combined" in html
+
+
+def test_email_includes_relationship_when_present():
+    alert = _make_alert(relationship_score=0.90)
+    html = _build_email_html(alert)
+    assert "Relationship" in html
+    assert "90%" in html

--- a/backend/tests/test_e2e.py
+++ b/backend/tests/test_e2e.py
@@ -3,6 +3,7 @@
 End-to-end integration test: register → profile → ingest → alert created.
 Runs against test database. Mocks LLM and delivery channels.
 """
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from app.main import app
@@ -21,23 +22,26 @@ async def test_full_pipeline_end_to_end(client):
     """
 
     # Step 1: Register
-    resp = await client.post("/workspace/register", json={
-        "workspace_name": "E2E Test Agency",
-        "email": "e2e@test.com",
-        "password": "testpassword"
-    })
+    resp = await client.post(
+        "/workspace/register",
+        json={
+            "workspace_name": "E2E Test Agency",
+            "email": "e2e@test.com",
+            "password": "testpassword",
+        },
+    )
     assert resp.status_code == 201
 
     # Step 2: Login
-    login = await client.post("/auth/token", data={
-        "username": "e2e@test.com", "password": "testpassword"
-    })
+    login = await client.post(
+        "/auth/token", data={"username": "e2e@test.com", "password": "testpassword"}
+    )
     assert login.status_code == 200
     token = login.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
 
     # Step 3: Extract profile (mock LLM + embedding)
-    mock_profile_json = '''{
+    mock_profile_json = """{
         "company_name": "E2E Test Agency",
         "company_description": "We build AI agents.",
         "primary_services": ["AI agents"],
@@ -47,21 +51,33 @@ async def test_full_pipeline_end_to_end(client):
         "signal_keywords": ["AI agent", "automation", "LLM"],
         "anti_keywords": ["happy birthday"],
         "capability_summary": "We build custom AI agents for SaaS automation."
-    }'''
+    }"""
+    mock_icp_json = '{"icp": "CTOs and VPs of Engineering at mid-market SaaS. Not competing AI vendors.", "seller_mirror": "Founders at AI agent startups. Headlines mention LLM or agent tooling."}'
 
     # FastAPI dependency overrides instead of patch() — impossible to defeat
     # with `from ... import ...` because the override layer sits above
     # Python's import binding. See #21.
+    #
+    # The handler makes two LLM calls: one for capability extraction (no system
+    # prompt) and one for ICP+seller_mirror (system prompt contains "sales
+    # intelligence analyst"). Route on that signal so each call gets valid JSON.
+    async def _fake_complete(prompt, model=None, *, system=None, max_tokens=2048):
+        if system and "sales intelligence analyst" in system.lower():
+            return mock_icp_json
+        return mock_profile_json
+
     fake_llm = MagicMock()
-    fake_llm.complete = AsyncMock(return_value=mock_profile_json)
+    fake_llm.complete = _fake_complete
     fake_emb = MagicMock()
     fake_emb.embed = AsyncMock(return_value=[0.5] * 1536)
     app.dependency_overrides[get_llm_client] = lambda: fake_llm
     app.dependency_overrides[get_embedding_provider] = lambda: fake_emb
     try:
-        resp = await client.post("/profile/extract", json={
-            "text": "We build custom AI agents for SaaS companies."
-        }, headers=headers)
+        resp = await client.post(
+            "/profile/extract",
+            json={"text": "We build custom AI agents for SaaS companies."},
+            headers=headers,
+        )
         assert resp.status_code == 200
         assert resp.json()["company_name"] == "E2E Test Agency"
     finally:
@@ -72,22 +88,28 @@ async def test_full_pipeline_end_to_end(client):
     with patch("app.routers.ingest.process_post_pipeline") as mock_task:
         mock_task.delay = MagicMock(return_value=MagicMock(id="task-e2e"))
 
-        resp = await client.post("/ingest", json={
-            "posts": [{
-                "linkedin_post_id": "urn:li:activity:e2etest001",
-                "author": {
-                    "name": "Test Person",
-                    "headline": "CTO at TestCo",
-                    "profile_url": "https://linkedin.com/in/testperson",
-                    "linkedin_id": "testperson",
-                    "degree": 1
-                },
-                "content": "Looking for AI agent solutions for our sales automation pipeline.",
-                "post_type": "post",
-                "posted_at": "2026-04-08T10:00:00Z"
-            }],
-            "extraction_version": "1.0.0"
-        }, headers=headers)
+        resp = await client.post(
+            "/ingest",
+            json={
+                "posts": [
+                    {
+                        "linkedin_post_id": "urn:li:activity:e2etest001",
+                        "author": {
+                            "name": "Test Person",
+                            "headline": "CTO at TestCo",
+                            "profile_url": "https://linkedin.com/in/testperson",
+                            "linkedin_id": "testperson",
+                            "degree": 1,
+                        },
+                        "content": "Looking for AI agent solutions for our sales automation pipeline.",
+                        "post_type": "post",
+                        "posted_at": "2026-04-08T10:00:00Z",
+                    }
+                ],
+                "extraction_version": "1.0.0",
+            },
+            headers=headers,
+        )
 
         assert resp.status_code == 202
         assert resp.json()["queued"] == 1

--- a/backend/tests/test_e2e.py
+++ b/backend/tests/test_e2e.py
@@ -58,11 +58,14 @@ async def test_full_pipeline_end_to_end(client):
     # with `from ... import ...` because the override layer sits above
     # Python's import binding. See #21.
     #
-    # The handler makes two LLM calls: one for capability extraction (no system
-    # prompt) and one for ICP+seller_mirror (system prompt contains "sales
-    # intelligence analyst"). Route on that signal so each call gets valid JSON.
+    # The handler makes two LLM calls: one for capability extraction and
+    # one for ICP+seller_mirror. Route by reference equality on the known
+    # prompt constant — a substring match would silently misroute if the
+    # prompt text is ever reworded, surfacing as a confusing parse error.
+    from app.prompts import extract_icp_and_seller_mirror as icp_prompt
+
     async def _fake_complete(prompt, model=None, *, system=None, max_tokens=2048):
-        if system and "sales intelligence analyst" in system.lower():
+        if system is icp_prompt.SYSTEM_PROMPT:
             return mock_icp_json
         return mock_profile_json
 

--- a/backend/tests/test_extract_icp_prompt.py
+++ b/backend/tests/test_extract_icp_prompt.py
@@ -1,0 +1,55 @@
+"""Prompt module: structure + schema validation.
+
+This file does NOT test LLM output quality (that's for calibration), only that
+the prompt module is well-formed: version set, system prompt static, user
+message builder interpolates the right inputs, schema validates realistic JSON.
+"""
+
+import pytest
+from jsonschema import validate, ValidationError
+
+from app.prompts import extract_icp_and_seller_mirror as mod
+
+
+def test_prompt_version_is_semver_like():
+    assert isinstance(mod.PROMPT_VERSION, str)
+    assert mod.PROMPT_VERSION.startswith("v")
+
+
+def test_system_prompt_is_static_and_nonempty():
+    assert isinstance(mod.SYSTEM_PROMPT, str)
+    assert len(mod.SYSTEM_PROMPT) > 100
+    # Must not contain user-controlled placeholders
+    assert "{" not in mod.SYSTEM_PROMPT
+    assert "}" not in mod.SYSTEM_PROMPT
+
+
+def test_build_user_message_interpolates_source_text():
+    source = "We sell CDP tooling for D2C brands."
+    msg = mod.build_user_message(source_text=source)
+    assert source in msg
+
+
+def test_build_user_message_rejects_empty():
+    with pytest.raises(ValueError):
+        mod.build_user_message(source_text="")
+
+
+def test_response_schema_validates_well_formed_output():
+    sample = {
+        "icp": "Marketing, growth, or e-commerce leaders at D2C or direct-to-consumer brands generating >$1M ARR. Not employees of martech SaaS vendors or competing agencies.",
+        "seller_mirror": "Founders, CEOs, CPOs, and sales directors at CDP / marketing-automation / customer-engagement SaaS companies. People whose LinkedIn headlines name-drop their own product.",
+    }
+    validate(instance=sample, schema=mod.RESPONSE_JSON_SCHEMA)
+
+
+def test_response_schema_rejects_missing_field():
+    sample = {"icp": "..."}  # missing seller_mirror
+    with pytest.raises(ValidationError):
+        validate(instance=sample, schema=mod.RESPONSE_JSON_SCHEMA)
+
+
+def test_response_schema_rejects_short_fields():
+    sample = {"icp": "short", "seller_mirror": "also short"}
+    with pytest.raises(ValidationError):
+        validate(instance=sample, schema=mod.RESPONSE_JSON_SCHEMA)

--- a/backend/tests/test_extract_icp_prompt.py
+++ b/backend/tests/test_extract_icp_prompt.py
@@ -35,10 +35,28 @@ def test_build_user_message_rejects_empty():
         mod.build_user_message(source_text="")
 
 
+def test_build_user_message_rejects_whitespace_only():
+    # Browser forms submitting blank space is the realistic footgun, not ""
+    with pytest.raises(ValueError):
+        mod.build_user_message(source_text="   \n\t   ")
+
+
 def test_response_schema_validates_well_formed_output():
     sample = {
-        "icp": "Marketing, growth, or e-commerce leaders at D2C or direct-to-consumer brands generating >$1M ARR. Not employees of martech SaaS vendors or competing agencies.",
-        "seller_mirror": "Founders, CEOs, CPOs, and sales directors at CDP / marketing-automation / customer-engagement SaaS companies. People whose LinkedIn headlines name-drop their own product.",
+        "icp": (
+            "Marketing, growth, or e-commerce leaders (Head of Growth, VP "
+            "Marketing, Director of E-commerce, CMO) at D2C or direct-to-consumer "
+            "brands generating roughly $1M to $50M ARR. Must own budget for "
+            "outbound or retention tooling. Not employees of martech SaaS "
+            "vendors, competing agencies, or consultancies serving martech."
+        ),
+        "seller_mirror": (
+            "Founders, CEOs, CPOs, Heads of Product, and sales directors at CDP, "
+            "marketing-automation, or customer-engagement SaaS companies. "
+            "LinkedIn headlines typically name-drop the product (e.g., 'CEO at "
+            "Acme CDP'), include stage signals like 'Series A' or 'YC W23', and "
+            "reference direct competitors or adjacent category terms."
+        ),
     }
     validate(instance=sample, schema=mod.RESPONSE_JSON_SCHEMA)
 

--- a/backend/tests/test_fit_scorer.py
+++ b/backend/tests/test_fit_scorer.py
@@ -1,0 +1,137 @@
+"""Unit tests for fit_scorer — pure math, no DB, no LLM."""
+
+from datetime import datetime, timedelta, timezone
+import math
+
+import pytest
+
+from app.services.fit_scorer import (
+    cosine_similarity,
+    compute_fit_score,
+    compute_intent_score,
+    compute_hybrid_score,
+)
+
+
+# ---------- cosine_similarity ----------
+
+
+def test_cosine_similarity_identical_vectors():
+    v = [1.0, 0.0, 0.0]
+    assert math.isclose(cosine_similarity(v, v), 1.0)
+
+
+def test_cosine_similarity_orthogonal_vectors():
+    assert math.isclose(cosine_similarity([1.0, 0.0], [0.0, 1.0]), 0.0)
+
+
+def test_cosine_similarity_opposite_vectors():
+    assert math.isclose(cosine_similarity([1.0, 0.0], [-1.0, 0.0]), -1.0)
+
+
+def test_cosine_similarity_zero_vector_returns_zero():
+    assert cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+# ---------- compute_fit_score ----------
+
+
+def test_fit_score_pure_icp_match_no_seller_signal():
+    # ICP matches perfectly; seller signal absent
+    icp_emb = [1.0, 0.0, 0.0]
+    mirror_emb = [0.0, 1.0, 0.0]
+    conn_emb = [1.0, 0.0, 0.0]  # perfect ICP, zero seller
+    fit = compute_fit_score(icp_emb, mirror_emb, conn_emb, lambda_=0.3)
+    assert math.isclose(fit, 1.0, abs_tol=1e-6)
+
+
+def test_fit_score_pure_seller_match_floored_at_zero():
+    # Connection is a perfect seller mirror, nothing like ICP
+    icp_emb = [1.0, 0.0, 0.0]
+    mirror_emb = [0.0, 1.0, 0.0]
+    conn_emb = [0.0, 1.0, 0.0]  # perfect mirror → raw = 0 - 0.3*1 = -0.3
+    fit = compute_fit_score(icp_emb, mirror_emb, conn_emb, lambda_=0.3)
+    assert fit == 0.0, "negative raw fit must floor at 0"
+
+
+def test_fit_score_lambda_zero_equals_raw_icp_cosine():
+    icp_emb = [1.0, 0.0, 0.0]
+    mirror_emb = [0.0, 1.0, 0.0]
+    conn_emb = [0.8, 0.6, 0.0]
+    expected = cosine_similarity(icp_emb, conn_emb)  # 0.8
+    assert math.isclose(
+        compute_fit_score(icp_emb, mirror_emb, conn_emb, lambda_=0.0),
+        expected,
+        abs_tol=1e-6,
+    )
+
+
+def test_fit_score_lambda_one_subtracts_full_mirror_term():
+    icp_emb = [1.0, 0.0, 0.0]
+    mirror_emb = [0.0, 1.0, 0.0]
+    conn_emb = [0.8, 0.6, 0.0]
+    # raw = 0.8 - 1.0*0.6 = 0.2
+    assert math.isclose(
+        compute_fit_score(icp_emb, mirror_emb, conn_emb, lambda_=1.0),
+        0.2,
+        abs_tol=1e-6,
+    )
+
+
+def test_fit_score_dimension_mismatch_raises():
+    with pytest.raises(ValueError):
+        compute_fit_score([1.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0], lambda_=0.3)
+
+
+def test_fit_score_negative_lambda_raises():
+    with pytest.raises(ValueError):
+        compute_fit_score([1.0], [0.5], [1.0], lambda_=-0.1)
+
+
+# ---------- compute_intent_score ----------
+
+
+def test_intent_score_fresh_post_full_relevance():
+    now = datetime.now(timezone.utc)
+    score = compute_intent_score(relevance_score=1.0, posted_at=now)
+    assert math.isclose(score, 1.0, abs_tol=1e-3)  # 0.7*1 + 0.3*1 = 1
+
+
+def test_intent_score_stale_post_timing_decayed_to_zero():
+    then = datetime.now(timezone.utc) - timedelta(hours=48)
+    score = compute_intent_score(relevance_score=1.0, posted_at=then)
+    # relevance 1 * 0.7 + timing 0 * 0.3 = 0.7
+    assert math.isclose(score, 0.7, abs_tol=1e-3)
+
+
+def test_intent_score_mid_decay():
+    then = datetime.now(timezone.utc) - timedelta(hours=12)
+    score = compute_intent_score(relevance_score=0.5, posted_at=then)
+    # relevance 0.5 * 0.7 + timing 0.5 * 0.3 = 0.35 + 0.15 = 0.5
+    assert math.isclose(score, 0.5, abs_tol=1e-2)
+
+
+def test_intent_score_clamped_to_unit_interval():
+    now = datetime.now(timezone.utc)
+    assert 0.0 <= compute_intent_score(relevance_score=0.0, posted_at=now) <= 1.0
+    assert 0.0 <= compute_intent_score(relevance_score=1.5, posted_at=now) <= 1.0
+
+
+# ---------- compute_hybrid_score ----------
+
+
+def test_hybrid_score_multiplies_fit_and_intent():
+    assert math.isclose(compute_hybrid_score(fit_score=0.4, intent_score=0.9), 0.36)
+
+
+def test_hybrid_score_zero_fit_suppresses():
+    """The Lipi Mittal fix: low fit zeros out regardless of intent."""
+    assert compute_hybrid_score(fit_score=0.0, intent_score=0.95) == 0.0
+
+
+def test_hybrid_score_zero_intent_suppresses():
+    assert compute_hybrid_score(fit_score=0.8, intent_score=0.0) == 0.0
+
+
+def test_hybrid_score_clamps_to_unit_interval():
+    assert compute_hybrid_score(fit_score=1.0, intent_score=1.0) == 1.0

--- a/backend/tests/test_fit_scorer.py
+++ b/backend/tests/test_fit_scorer.py
@@ -91,41 +91,61 @@ def test_fit_score_negative_lambda_raises():
 # ---------- compute_intent_score ----------
 
 
+# Fixed sentinel "now" so every intent-score test is deterministic. Using
+# datetime.now() in the test body would (a) violate CLAUDE.md's "no
+# datetime.now() in tests" rule and (b) make the timing term drift relative
+# to the implementation's own now(), forcing loose abs_tol. Passing the same
+# `now` into both sides gives exact equality.
+FIXED_NOW = datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc)
+
+
 def test_intent_score_fresh_post_full_relevance():
-    now = datetime.now(timezone.utc)
-    score = compute_intent_score(relevance_score=1.0, posted_at=now)
-    assert math.isclose(score, 1.0, abs_tol=1e-3)  # 0.7*1 + 0.3*1 = 1
+    score = compute_intent_score(
+        relevance_score=1.0, posted_at=FIXED_NOW, now=FIXED_NOW
+    )
+    # 0.7 * 1 + 0.3 * 1 = 1.0 exactly
+    assert math.isclose(score, 1.0, abs_tol=1e-9)
 
 
 def test_intent_score_stale_post_timing_decayed_to_zero():
-    then = datetime.now(timezone.utc) - timedelta(hours=48)
-    score = compute_intent_score(relevance_score=1.0, posted_at=then)
+    then = FIXED_NOW - timedelta(hours=48)
+    score = compute_intent_score(relevance_score=1.0, posted_at=then, now=FIXED_NOW)
     # relevance 1 * 0.7 + timing 0 * 0.3 = 0.7
-    assert math.isclose(score, 0.7, abs_tol=1e-3)
+    assert math.isclose(score, 0.7, abs_tol=1e-9)
 
 
 def test_intent_score_mid_decay():
-    then = datetime.now(timezone.utc) - timedelta(hours=12)
-    score = compute_intent_score(relevance_score=0.5, posted_at=then)
+    then = FIXED_NOW - timedelta(hours=12)
+    score = compute_intent_score(relevance_score=0.5, posted_at=then, now=FIXED_NOW)
     # relevance 0.5 * 0.7 + timing 0.5 * 0.3 = 0.35 + 0.15 = 0.5
-    assert math.isclose(score, 0.5, abs_tol=1e-2)
+    assert math.isclose(score, 0.5, abs_tol=1e-9)
 
 
 def test_intent_score_clamped_to_unit_interval():
-    now = datetime.now(timezone.utc)
-    assert 0.0 <= compute_intent_score(relevance_score=0.0, posted_at=now) <= 1.0
-    assert 0.0 <= compute_intent_score(relevance_score=1.5, posted_at=now) <= 1.0
+    assert (
+        0.0
+        <= compute_intent_score(relevance_score=0.0, posted_at=FIXED_NOW, now=FIXED_NOW)
+        <= 1.0
+    )
+    assert (
+        0.0
+        <= compute_intent_score(relevance_score=1.5, posted_at=FIXED_NOW, now=FIXED_NOW)
+        <= 1.0
+    )
 
 
 # ---------- compute_hybrid_score ----------
 
 
 def test_hybrid_score_multiplies_fit_and_intent():
-    assert math.isclose(compute_hybrid_score(fit_score=0.4, intent_score=0.9), 0.36)
+    assert math.isclose(
+        compute_hybrid_score(fit_score=0.4, intent_score=0.9), 0.36, abs_tol=1e-9
+    )
 
 
 def test_hybrid_score_zero_fit_suppresses():
-    """The Lipi Mittal fix: low fit zeros out regardless of intent."""
+    """Low fit zeros out regardless of intent — the core Phase 2.6 fix.
+    See docs/phase-2-6/design.md §3.5 for the motivating failure mode."""
     assert compute_hybrid_score(fit_score=0.0, intent_score=0.95) == 0.0
 
 

--- a/backend/tests/test_migration_008_009_010.py
+++ b/backend/tests/test_migration_008_009_010.py
@@ -1,0 +1,60 @@
+"""Round-trip test: head → 007 → head works without errors and preserves row counts."""
+
+import pytest
+from sqlalchemy import text
+from alembic import command
+from alembic.config import Config
+
+
+@pytest.fixture
+def alembic_cfg() -> Config:
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("script_location", "alembic")
+    return cfg
+
+
+def test_migrations_008_009_010_round_trip(alembic_cfg: Config):
+    """Upgrade to head, downgrade to 007, upgrade to head. Should not error."""
+    command.upgrade(alembic_cfg, "head")
+    command.downgrade(alembic_cfg, "007")
+    command.upgrade(alembic_cfg, "head")
+
+
+def test_new_columns_present_after_upgrade(alembic_cfg: Config, sync_engine):
+    """After head, the 6 new columns exist with correct types and defaults."""
+    command.upgrade(alembic_cfg, "head")
+    with sync_engine.connect() as conn:
+        # Migration 008
+        row = conn.execute(
+            text(
+                "SELECT column_name, data_type, is_nullable "
+                "FROM information_schema.columns "
+                "WHERE table_name='connections' AND column_name='fit_score'"
+            )
+        ).fetchone()
+        assert row is not None, "connections.fit_score missing"
+        assert row.data_type == "real"
+        assert row.is_nullable == "YES"
+
+        # Migration 009
+        row = conn.execute(
+            text(
+                "SELECT column_name, data_type, is_nullable, column_default "
+                "FROM information_schema.columns "
+                "WHERE table_name='workspaces' AND column_name='use_hybrid_scoring'"
+            )
+        ).fetchone()
+        assert row is not None, "workspaces.use_hybrid_scoring missing"
+        assert row.data_type == "boolean"
+        assert row.is_nullable == "NO"
+        assert "false" in (row.column_default or "").lower()
+
+        # Migration 010
+        for col in ("icp", "seller_mirror", "icp_embedding", "seller_mirror_embedding"):
+            row = conn.execute(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    f"WHERE table_name='capability_profile_versions' AND column_name='{col}'"
+                )
+            ).fetchone()
+            assert row is not None, f"capability_profile_versions.{col} missing"

--- a/backend/tests/test_migration_008_009_010.py
+++ b/backend/tests/test_migration_008_009_010.py
@@ -5,11 +5,22 @@ from sqlalchemy import text
 from alembic import command
 from alembic.config import Config
 
+from app.config import get_settings
+
 
 @pytest.fixture
 def alembic_cfg() -> Config:
+    """Alembic config pinned to the isolated sonar_test database.
+
+    Without the explicit sqlalchemy.url override, alembic.ini's default
+    points at the main sonar database. Running this test against a live
+    dev stack would destructively downgrade the dev schema mid-run.
+    """
     cfg = Config("alembic.ini")
     cfg.set_main_option("script_location", "alembic")
+    base_url = get_settings().database_url.replace("+asyncpg", "")
+    test_db_url = base_url.rsplit("/", 1)[0] + "/sonar_test"
+    cfg.set_main_option("sqlalchemy.url", test_db_url)
     return cfg
 
 
@@ -24,7 +35,8 @@ def test_new_columns_present_after_upgrade(alembic_cfg: Config, sync_engine):
     """After head, the 6 new columns exist with correct types and defaults."""
     command.upgrade(alembic_cfg, "head")
     with sync_engine.connect() as conn:
-        # Migration 008
+        # Migration 008 — fit_score. sa.Float() maps to Postgres double precision,
+        # matching the neighbour relationship_score column on the same table.
         row = conn.execute(
             text(
                 "SELECT column_name, data_type, is_nullable "
@@ -33,10 +45,10 @@ def test_new_columns_present_after_upgrade(alembic_cfg: Config, sync_engine):
             )
         ).fetchone()
         assert row is not None, "connections.fit_score missing"
-        assert row.data_type == "real"
+        assert row.data_type == "double precision"
         assert row.is_nullable == "YES"
 
-        # Migration 009
+        # Migration 009 — use_hybrid_scoring.
         row = conn.execute(
             text(
                 "SELECT column_name, data_type, is_nullable, column_default "
@@ -49,12 +61,32 @@ def test_new_columns_present_after_upgrade(alembic_cfg: Config, sync_engine):
         assert row.is_nullable == "NO"
         assert "false" in (row.column_default or "").lower()
 
-        # Migration 010
-        for col in ("icp", "seller_mirror", "icp_embedding", "seller_mirror_embedding"):
+        # Migration 010 — text columns. Bindparam (not f-string) per the
+        # project's "parameterized SQL always" rule, even in test code.
+        for col in ("icp", "seller_mirror"):
             row = conn.execute(
                 text(
-                    "SELECT column_name FROM information_schema.columns "
-                    f"WHERE table_name='capability_profile_versions' AND column_name='{col}'"
-                )
+                    "SELECT column_name, data_type FROM information_schema.columns "
+                    "WHERE table_name='capability_profile_versions' "
+                    "AND column_name=:c"
+                ),
+                {"c": col},
             ).fetchone()
             assert row is not None, f"capability_profile_versions.{col} missing"
+            assert row.data_type == "text"
+
+        # Migration 010 — pgvector columns. Postgres reports
+        # data_type='USER-DEFINED' for extension types; we assert the
+        # specific udt_name='vector' so a future regression (dropped
+        # pgvector extension, swapped type) would fail loudly.
+        for col in ("icp_embedding", "seller_mirror_embedding"):
+            row = conn.execute(
+                text(
+                    "SELECT column_name, udt_name FROM information_schema.columns "
+                    "WHERE table_name='capability_profile_versions' "
+                    "AND column_name=:c"
+                ),
+                {"c": col},
+            ).fetchone()
+            assert row is not None, f"capability_profile_versions.{col} missing"
+            assert row.udt_name == "vector", f"{col} is not pgvector type"

--- a/backend/tests/test_pipeline_hybrid_scoring.py
+++ b/backend/tests/test_pipeline_hybrid_scoring.py
@@ -148,3 +148,129 @@ async def test_pipeline_hybrid_path_when_flag_true(
     assert 0.0 <= post.combined_score <= 1.0
     assert conn.fit_score is not None
     assert 0.0 <= conn.fit_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_hybrid_alert_has_null_relationship_score(
+    db_session, pipeline_setup, monkeypatch
+):
+    """flag=True: the Alert row must have relationship_score=None.
+
+    The hybrid path sets scoring.relationship_score=0.0 internally (the
+    axis moves to the dashboard degree filter), but that 0.0 must NOT flow
+    into the Alert row — formatters would render "Relationship: 0%" which
+    looks broken.  Issue #120.
+    """
+    workspace_id, post_id, connection_id = await pipeline_setup(use_hybrid=True)
+
+    from app.config import get_settings
+    from app.services import embedding as emb_module
+
+    settings = get_settings()
+    base_url = settings.database_url
+    test_db_url = base_url.rsplit("/", 1)[0] + "/sonar_test"
+    monkeypatch.setattr(settings, "database_url", test_db_url)
+
+    dummy_emb = [0.1] * 1536
+
+    async def fake_embed(text_in):
+        return dummy_emb
+
+    monkeypatch.setattr(emb_module.embedding_provider, "embed", fake_embed)
+
+    from app.services import context_generator as ctx_mod
+
+    async def fake_ctx(**kwargs):
+        return ctx_mod.AlertContext(
+            match_reason="test match",
+            outreach_draft_a="test a",
+            outreach_draft_b="test b",
+            opportunity_type="product_pain",
+            urgency_reason="test urgency",
+            themes=["data tooling"],
+        )
+
+    monkeypatch.setattr(ctx_mod, "generate_alert_context", fake_ctx)
+
+    from app.delivery import router as router_mod
+
+    class NoopRouter:
+        async def deliver(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(router_mod, "DeliveryRouter", lambda: NoopRouter())
+
+    from app.workers.pipeline import _run_pipeline
+    from app.models.alert import Alert
+
+    await _run_pipeline(post_id, workspace_id)
+
+    alert = (
+        await db_session.execute(select(Alert).where(Alert.post_id == post_id))
+    ).scalar_one()
+
+    assert (
+        alert.relationship_score is None
+    ), f"Expected relationship_score=None on hybrid alert, got {alert.relationship_score}"
+
+
+@pytest.mark.asyncio
+async def test_legacy_alert_has_non_null_relationship_score(
+    db_session, pipeline_setup, monkeypatch
+):
+    """flag=False: the Alert row must have a non-None relationship_score.
+
+    Regression guard: the nullable-column change must not break the legacy path.
+    """
+    workspace_id, post_id, connection_id = await pipeline_setup(use_hybrid=False)
+
+    from app.config import get_settings
+    from app.services import embedding as emb_module
+
+    settings = get_settings()
+    base_url = settings.database_url
+    test_db_url = base_url.rsplit("/", 1)[0] + "/sonar_test"
+    monkeypatch.setattr(settings, "database_url", test_db_url)
+
+    dummy_emb = [0.1] * 1536
+
+    async def fake_embed(text_in):
+        return dummy_emb
+
+    monkeypatch.setattr(emb_module.embedding_provider, "embed", fake_embed)
+
+    from app.services import context_generator as ctx_mod
+
+    async def fake_ctx(**kwargs):
+        return ctx_mod.AlertContext(
+            match_reason="test match",
+            outreach_draft_a="test a",
+            outreach_draft_b="test b",
+            opportunity_type="product_pain",
+            urgency_reason="test urgency",
+            themes=["data tooling"],
+        )
+
+    monkeypatch.setattr(ctx_mod, "generate_alert_context", fake_ctx)
+
+    from app.delivery import router as router_mod
+
+    class NoopRouter:
+        async def deliver(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(router_mod, "DeliveryRouter", lambda: NoopRouter())
+
+    from app.workers.pipeline import _run_pipeline
+    from app.models.alert import Alert
+
+    await _run_pipeline(post_id, workspace_id)
+
+    alert = (
+        await db_session.execute(select(Alert).where(Alert.post_id == post_id))
+    ).scalar_one()
+
+    assert (
+        alert.relationship_score is not None
+    ), "Expected a non-None relationship_score on legacy alert"
+    assert 0.0 <= alert.relationship_score <= 1.0

--- a/backend/tests/test_pipeline_hybrid_scoring.py
+++ b/backend/tests/test_pipeline_hybrid_scoring.py
@@ -1,0 +1,150 @@
+"""Pipeline branches on workspace.use_hybrid_scoring.
+
+Case A: flag=False → existing compute_combined_score path; post stored with
+relationship/timing/combined scores, no fit_score on the connection.
+
+Case B: flag=True → hybrid path; post's combined_score = fit_score * intent_score
+(where fit_score comes from connection.fit_score and intent_score from
+relevance + timing), connection.fit_score is populated if null.
+"""
+
+import pytest
+from sqlalchemy import select
+
+from app.models.connection import Connection
+from app.models.post import Post
+
+
+@pytest.mark.asyncio
+async def test_pipeline_legacy_path_when_flag_false(
+    db_session, pipeline_setup, monkeypatch
+):
+    """flag=False: uses compute_combined_score (existing behavior)."""
+    workspace_id, post_id, connection_id = await pipeline_setup(use_hybrid=False)
+
+    # Redirect the pipeline's engine to sonar_test (same DB the fixture used).
+    from app.config import get_settings
+    from app.services import embedding as emb_module
+
+    settings = get_settings()
+    base_url = settings.database_url
+    test_db_url = base_url.rsplit("/", 1)[0] + "/sonar_test"
+    monkeypatch.setattr(settings, "database_url", test_db_url)
+
+    dummy_emb = [0.1] * 1536
+
+    async def fake_embed(text_in):
+        return dummy_emb
+
+    monkeypatch.setattr(emb_module.embedding_provider, "embed", fake_embed)
+
+    from app.services import context_generator as ctx_mod
+
+    async def fake_ctx(**kwargs):
+        return ctx_mod.AlertContext(
+            match_reason="test match",
+            outreach_draft_a="test a",
+            outreach_draft_b="test b",
+            opportunity_type="product_pain",
+            urgency_reason="test urgency",
+            themes=["data tooling"],
+        )
+
+    monkeypatch.setattr(ctx_mod, "generate_alert_context", fake_ctx)
+
+    from app.delivery import router as router_mod
+
+    class NoopRouter:
+        async def deliver(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(router_mod, "DeliveryRouter", lambda: NoopRouter())
+
+    from app.workers.pipeline import _run_pipeline
+
+    await _run_pipeline(post_id, workspace_id)
+
+    post = (
+        await db_session.execute(select(Post).where(Post.id == post_id))
+    ).scalar_one()
+    await db_session.refresh(post)
+
+    conn = (
+        await db_session.execute(
+            select(Connection).where(Connection.id == connection_id)
+        )
+    ).scalar_one()
+    await db_session.refresh(conn)
+
+    assert post.combined_score is not None
+    assert post.relationship_score is not None
+    # Legacy path does not populate fit_score on the connection
+    assert conn.fit_score is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_hybrid_path_when_flag_true(
+    db_session, pipeline_setup, monkeypatch
+):
+    """flag=True: uses compute_hybrid_score. Stores fit_score on the connection."""
+    workspace_id, post_id, connection_id = await pipeline_setup(use_hybrid=True)
+
+    # Redirect the pipeline's engine to sonar_test (same DB the fixture used).
+    from app.config import get_settings
+    from app.services import embedding as emb_module
+
+    settings = get_settings()
+    base_url = settings.database_url
+    test_db_url = base_url.rsplit("/", 1)[0] + "/sonar_test"
+    monkeypatch.setattr(settings, "database_url", test_db_url)
+
+    dummy_emb = [0.1] * 1536
+
+    async def fake_embed(text_in):
+        return dummy_emb
+
+    monkeypatch.setattr(emb_module.embedding_provider, "embed", fake_embed)
+
+    from app.services import context_generator as ctx_mod
+
+    async def fake_ctx(**kwargs):
+        return ctx_mod.AlertContext(
+            match_reason="test match",
+            outreach_draft_a="test a",
+            outreach_draft_b="test b",
+            opportunity_type="product_pain",
+            urgency_reason="test urgency",
+            themes=["data tooling"],
+        )
+
+    monkeypatch.setattr(ctx_mod, "generate_alert_context", fake_ctx)
+
+    from app.delivery import router as router_mod
+
+    class NoopRouter:
+        async def deliver(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(router_mod, "DeliveryRouter", lambda: NoopRouter())
+
+    from app.workers.pipeline import _run_pipeline
+
+    await _run_pipeline(post_id, workspace_id)
+
+    post = (
+        await db_session.execute(select(Post).where(Post.id == post_id))
+    ).scalar_one()
+    await db_session.refresh(post)
+
+    conn = (
+        await db_session.execute(
+            select(Connection).where(Connection.id == connection_id)
+        )
+    ).scalar_one()
+    await db_session.refresh(conn)
+
+    # Hybrid path: combined_score = fit * intent
+    assert post.combined_score is not None
+    assert 0.0 <= post.combined_score <= 1.0
+    assert conn.fit_score is not None
+    assert 0.0 <= conn.fit_score <= 1.0

--- a/backend/tests/test_profile_extract_icp.py
+++ b/backend/tests/test_profile_extract_icp.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 
 from app.models.workspace import CapabilityProfileVersion
+from app.prompts import extract_icp_and_seller_mirror as icp_prompt
 
 
 class _FakeLLMForICP:
@@ -17,7 +18,10 @@ class _FakeLLMForICP:
 
     async def complete(self, prompt, model=None, *, system=None, max_tokens=2048):
         self.calls.append(("complete", system, prompt[:60]))
-        if "sales intelligence analyst" in (system or "").lower():
+        # Route by reference equality on the known prompt constant so that
+        # any future rewording of SYSTEM_PROMPT doesn't silently misroute
+        # this fake and surface as a confusing parse error.
+        if system is icp_prompt.SYSTEM_PROMPT:
             # ICP prompt
             return json.dumps(
                 {
@@ -72,8 +76,14 @@ async def test_profile_extract_persists_icp_and_seller_mirror(
             headers=auth_headers,
         )
     finally:
+        # Exhaustive cleanup — don't rely on the outer `client` fixture's
+        # dependency_overrides.clear() to sweep get_current_user, since that
+        # couples teardown safety to fixture ordering.
+        from app.routers.auth import get_current_user
+
         app.dependency_overrides.pop(get_llm_client, None)
         app.dependency_overrides.pop(get_embedding_provider, None)
+        app.dependency_overrides.pop(get_current_user, None)
 
     assert resp.status_code == 200, resp.text
     body = resp.json()

--- a/backend/tests/test_profile_extract_icp.py
+++ b/backend/tests/test_profile_extract_icp.py
@@ -1,0 +1,96 @@
+"""Integration test: POST /profile/extract persists ICP + seller_mirror."""
+
+import json
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.workspace import CapabilityProfileVersion
+
+
+class _FakeLLMForICP:
+    """Returns capability JSON first, then ICP+mirror JSON."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def complete(self, prompt, model=None, *, system=None, max_tokens=2048):
+        self.calls.append(("complete", system, prompt[:60]))
+        if "sales intelligence analyst" in (system or "").lower():
+            # ICP prompt
+            return json.dumps(
+                {
+                    "icp": "Marketing and growth leaders at D2C brands. Not competing martech vendors or agency employees. Must own a budget for outbound tooling.",
+                    "seller_mirror": "Founders, CEOs, CPOs at CDP or marketing-automation SaaS companies. LinkedIn headlines typically name-drop the product and include Series A/B signals.",
+                }
+            )
+        # Capability prompt (existing path)
+        return json.dumps(
+            {
+                "company_name": "Acme CDP",
+                "company_description": "A customer data platform for D2C brands.",
+                "primary_services": ["CDP"],
+                "target_customers": ["D2C brands"],
+                "pain_points_solved": ["data fragmentation"],
+                "technologies_used": ["Python"],
+                "signal_keywords": ["customer data", "cdp migration"],
+                "anti_keywords": ["looking for job"],
+                "capability_summary": "We sell a CDP for D2C brands.",
+            }
+        )
+
+
+class _FakeEmbedding:
+    async def embed(self, text: str) -> list[float]:
+        # Deterministic fake embedding keyed by first char, so we can distinguish
+        # ICP / seller_mirror / capability in assertions
+        seed = ord(text[0]) if text else 0
+        return [float((seed + i) % 10) / 10.0 for i in range(1536)]
+
+
+@pytest.mark.asyncio
+async def test_profile_extract_persists_icp_and_seller_mirror(
+    client: AsyncClient,
+    db_session,
+    auth_headers,
+    workspace_id,
+):
+    from app.main import app
+    from app.services.embedding import get_embedding_provider
+    from app.services.llm import get_llm_client
+
+    fake_llm = _FakeLLMForICP()
+    fake_emb = _FakeEmbedding()
+    app.dependency_overrides[get_llm_client] = lambda: fake_llm
+    app.dependency_overrides[get_embedding_provider] = lambda: fake_emb
+
+    try:
+        resp = await client.post(
+            "/profile/extract",
+            json={"text": "Acme CDP sells customer-data tooling to D2C brands."},
+            headers=auth_headers,
+        )
+    finally:
+        app.dependency_overrides.pop(get_llm_client, None)
+        app.dependency_overrides.pop(get_embedding_provider, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["icp"].startswith("Marketing")
+    assert body["seller_mirror"].startswith("Founders")
+
+    row = (
+        await db_session.execute(
+            select(CapabilityProfileVersion)
+            .where(CapabilityProfileVersion.workspace_id == workspace_id)
+            .where(CapabilityProfileVersion.is_active.is_(True))
+        )
+    ).scalar_one()
+
+    assert row.icp is not None and "D2C" in row.icp
+    assert row.seller_mirror is not None and "CDP" in row.seller_mirror
+    assert row.icp_embedding is not None
+    assert len(list(row.icp_embedding)) == 1536
+    assert row.seller_mirror_embedding is not None
+    assert len(list(row.seller_mirror_embedding)) == 1536

--- a/backend/tests/test_profile_update_icp.py
+++ b/backend/tests/test_profile_update_icp.py
@@ -125,6 +125,28 @@ async def test_update_icp_requires_at_least_one_field(
 
 
 @pytest.mark.asyncio
+async def test_update_icp_rejects_whitespace_only(
+    client: AsyncClient,
+    db_session,
+    auth_headers,
+    workspace_id,
+):
+    """Whitespace-only strings must be treated as missing, not embedded.
+    Without the strip + non-empty check, the endpoint would happily embed
+    "   \\n\\t " and corrupt the active profile's ICP signal."""
+    await _seed_active_version(db_session, workspace_id)
+
+    resp = await client.post(
+        "/profile/update-icp",
+        json={"icp": "   ", "seller_mirror": "\n\t "},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 400
+    assert "non-empty" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
 async def test_update_icp_accepts_icp_only(
     client: AsyncClient,
     db_session,

--- a/backend/tests/test_profile_update_icp.py
+++ b/backend/tests/test_profile_update_icp.py
@@ -1,0 +1,172 @@
+"""Integration tests: POST /profile/update-icp updates ICP text and re-embeds."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.workspace import CapabilityProfileVersion
+
+
+class _FakeEmbedding:
+    """Deterministic fake embedding keyed by first char for distinguishability."""
+
+    async def embed(self, text: str) -> list[float]:
+        seed = ord(text[0]) if text else 0
+        return [float((seed + i) % 10) / 10.0 for i in range(1536)]
+
+
+async def _seed_active_version(db_session, workspace_id):
+    """Insert an active CapabilityProfileVersion for the given workspace."""
+    from sqlalchemy import text as sql_text
+
+    profile = CapabilityProfileVersion(
+        workspace_id=workspace_id,
+        version=1,
+        raw_text="Acme CDP: customer data platform for D2C brands.",
+        source="text",
+        signal_keywords=["cdp"],
+        anti_keywords=[],
+        icp="Original ICP text. Marketing leaders at D2C brands.",
+        seller_mirror="Original seller mirror. Founders at martech SaaS.",
+        is_active=True,
+    )
+    db_session.add(profile)
+    await db_session.flush()
+
+    # Populate pgvector columns with a distinct initial embedding (all 0.1)
+    fake_emb = "[" + ",".join(["0.1"] * 1536) + "]"
+    await db_session.execute(
+        sql_text(
+            "UPDATE capability_profile_versions "
+            "SET embedding = CAST(:e AS vector), "
+            "    icp_embedding = CAST(:e AS vector), "
+            "    seller_mirror_embedding = CAST(:e AS vector) "
+            "WHERE id = :id"
+        ),
+        {"e": fake_emb, "id": str(profile.id)},
+    )
+    await db_session.commit()
+    return profile.id
+
+
+@pytest.mark.asyncio
+async def test_update_icp_updates_both_text_fields_and_reembeds(
+    client: AsyncClient,
+    db_session,
+    auth_headers,
+    workspace_id,
+):
+    from app.main import app
+    from app.services.embedding import get_embedding_provider
+
+    await _seed_active_version(db_session, workspace_id)
+
+    fake_emb = _FakeEmbedding()
+    app.dependency_overrides[get_embedding_provider] = lambda: fake_emb
+
+    try:
+        resp = await client.post(
+            "/profile/update-icp",
+            json={
+                "icp": "Updated ICP: CMOs at Series A SaaS startups.",
+                "seller_mirror": "Updated mirror: VCs and agency growth leads.",
+            },
+            headers=auth_headers,
+        )
+    finally:
+        app.dependency_overrides.pop(get_embedding_provider, None)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True}
+
+    # Expire and re-fetch to bypass session cache
+    await db_session.rollback()
+    row = (
+        await db_session.execute(
+            select(CapabilityProfileVersion)
+            .where(CapabilityProfileVersion.workspace_id == workspace_id)
+            .where(CapabilityProfileVersion.is_active.is_(True))
+        )
+    ).scalar_one()
+
+    assert row.icp == "Updated ICP: CMOs at Series A SaaS startups."
+    assert row.seller_mirror == "Updated mirror: VCs and agency growth leads."
+
+    # _FakeEmbedding seeds on first char; "U" = 85, "Updated ICP..." → different from 0.1
+    icp_emb = list(row.icp_embedding)
+    mirror_emb = list(row.seller_mirror_embedding)
+    assert len(icp_emb) == 1536
+    assert len(mirror_emb) == 1536
+    # Initial embeddings were all 0.1; fake embeds keyed to 'U' (85) should differ
+    assert not all(v == pytest.approx(0.1) for v in icp_emb)
+    assert not all(v == pytest.approx(0.1) for v in mirror_emb)
+
+
+@pytest.mark.asyncio
+async def test_update_icp_requires_at_least_one_field(
+    client: AsyncClient,
+    db_session,
+    auth_headers,
+    workspace_id,
+):
+    await _seed_active_version(db_session, workspace_id)
+
+    resp = await client.post(
+        "/profile/update-icp",
+        json={},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 400
+    assert (
+        "icp" in resp.json()["detail"].lower()
+        or "seller_mirror" in resp.json()["detail"].lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_icp_accepts_icp_only(
+    client: AsyncClient,
+    db_session,
+    auth_headers,
+    workspace_id,
+):
+    from app.main import app
+    from app.services.embedding import get_embedding_provider
+
+    await _seed_active_version(db_session, workspace_id)
+
+    fake_emb = _FakeEmbedding()
+    app.dependency_overrides[get_embedding_provider] = lambda: fake_emb
+
+    try:
+        resp = await client.post(
+            "/profile/update-icp",
+            json={"icp": "ICP-only update: Head of Growth at Fintech startups."},
+            headers=auth_headers,
+        )
+    finally:
+        app.dependency_overrides.pop(get_embedding_provider, None)
+
+    assert resp.status_code == 200, resp.text
+
+    await db_session.rollback()
+    row = (
+        await db_session.execute(
+            select(CapabilityProfileVersion)
+            .where(CapabilityProfileVersion.workspace_id == workspace_id)
+            .where(CapabilityProfileVersion.is_active.is_(True))
+        )
+    ).scalar_one()
+
+    # ICP text and embedding should be updated
+    assert row.icp == "ICP-only update: Head of Growth at Fintech startups."
+    icp_emb = list(row.icp_embedding)
+    assert len(icp_emb) == 1536
+    assert not all(v == pytest.approx(0.1) for v in icp_emb)
+
+    # seller_mirror text should remain unchanged
+    assert row.seller_mirror == "Original seller mirror. Founders at martech SaaS."
+    # seller_mirror_embedding should remain the initial 0.1 values
+    mirror_emb = list(row.seller_mirror_embedding)
+    assert all(v == pytest.approx(0.1) for v in mirror_emb)

--- a/backend/tests/test_prompt_logging.py
+++ b/backend/tests/test_prompt_logging.py
@@ -1,0 +1,166 @@
+"""Regression tests for PROMPT_VERSION structured logging.
+
+Every LLM call site that has a prompt module must emit a log record on the
+"app.prompts" logger after a successful call. These tests assert that the log
+fires with the expected fields so we catch any future call sites that drop the
+instrumentation.
+
+Issue #121.
+
+Implementation note on caplog + Alembic interaction
+----------------------------------------------------
+test_migration_008_009_010.py calls alembic.command.upgrade/downgrade which
+invokes logging.config.fileConfig with disable_existing_loggers=True (the
+Python default). This disables any logger that was created before the call but
+is not listed in alembic.ini — including "app.prompts". A disabled logger
+silently drops all records regardless of level or handlers. To keep these tests
+deterministic regardless of execution order we temporarily reset the disabled
+flag on the "app.prompts" logger via the _enable_prompts_logger fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from app.config import OPENAI_MODEL_EXPENSIVE
+
+
+@pytest.fixture(autouse=True)
+def _enable_prompts_logger():
+    """Re-enable the app.prompts logger for the duration of each test.
+
+    alembic.command.{upgrade,downgrade} calls logging.config.fileConfig which
+    sets disable_existing_loggers=True, disabling any logger not listed in
+    alembic.ini. Reset the flag here so tests run in any order.
+    """
+    logger = logging.getLogger("app.prompts")
+    was_disabled = logger.disabled
+    logger.disabled = False
+    yield
+    logger.disabled = was_disabled
+
+
+# ---------------------------------------------------------------------------
+# propose_signals — router-level (FastAPI DI pattern)
+# ---------------------------------------------------------------------------
+
+
+class _FakeLLMForPropose:
+    async def complete(
+        self,
+        prompt: str,
+        model: str,
+        *,
+        system: str | None = None,
+        max_tokens: int = 2048,
+    ) -> str:
+        return json.dumps(
+            {
+                "signals": [
+                    {
+                        "phrase": f"phrase {i}",
+                        "example_post": f"example post {i}",
+                        "intent_strength": 0.5,
+                    }
+                    for i in range(8)
+                ]
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_propose_signals_emits_prompt_version_log(client, db_session, caplog):
+    from app.main import app
+    from app.services.llm import get_llm_client
+
+    fake = _FakeLLMForPropose()
+    app.dependency_overrides[get_llm_client] = lambda: fake
+
+    await client.post(
+        "/workspace/register",
+        json={
+            "workspace_name": "LogTestWS",
+            "email": "logtest@example.com",
+            "password": "pass123",
+        },
+    )
+    tok = (
+        await client.post(
+            "/auth/token",
+            data={"username": "logtest@example.com", "password": "pass123"},
+        )
+    ).json()["access_token"]
+
+    with caplog.at_level(logging.INFO):
+        resp = await client.post(
+            "/workspace/signals/propose",
+            json={
+                "what_you_sell": "Fractional CTO services",
+                "icp": "CEOs at startups",
+            },
+            headers={"Authorization": f"Bearer {tok}"},
+        )
+
+    app.dependency_overrides.pop(get_llm_client, None)
+
+    assert resp.status_code == 200
+
+    log_records = [r for r in caplog.records if r.name == "app.prompts"]
+    assert len(log_records) == 1, f"Expected 1 prompt log, got {len(log_records)}"
+
+    record = log_records[0]
+    payload = record.__dict__["prompt_log"]
+    assert payload["feature"] == "propose_signals"
+    assert payload["prompt_version"] == "v1"
+    assert payload["model"] == OPENAI_MODEL_EXPENSIVE
+    assert "workspace_id" in payload
+
+
+# ---------------------------------------------------------------------------
+# extract_icp_and_seller_mirror — service-level (llm_override DI pattern)
+# ---------------------------------------------------------------------------
+
+
+class _FakeLLMForICP:
+    async def complete(
+        self,
+        prompt: str,
+        model: str = None,
+        *,
+        system: str | None = None,
+        max_tokens: int = 2048,
+    ) -> str:
+        return json.dumps(
+            {
+                "icp": "Marketing leaders at D2C brands. Not competing vendors.",
+                "seller_mirror": "Founders, CEOs at martech SaaS. Series A/B signals.",
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_extract_icp_emits_prompt_version_log(caplog):
+    from app.services.profile_extractor import extract_icp_and_seller_mirror
+
+    fake = _FakeLLMForICP()
+
+    with caplog.at_level(logging.INFO):
+        icp, seller_mirror = await extract_icp_and_seller_mirror(
+            source_text="Acme CDP sells customer-data tooling to D2C brands.",
+            llm_override=fake,
+        )
+
+    assert icp.startswith("Marketing")
+    assert seller_mirror.startswith("Founders")
+
+    log_records = [r for r in caplog.records if r.name == "app.prompts"]
+    assert len(log_records) == 1, f"Expected 1 prompt log, got {len(log_records)}"
+
+    record = log_records[0]
+    payload = record.__dict__["prompt_log"]
+    assert payload["feature"] == "extract_icp_and_seller_mirror"
+    assert payload["prompt_version"] == "v1"
+    assert payload["model"] == OPENAI_MODEL_EXPENSIVE

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -806,6 +806,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "kombu"
 version = "5.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1076,7 +1103,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.31.0"
+version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1088,9 +1115,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/fe/64b3d035780b3188f86c4f6f1bc202e7bb74757ef028802112273b9dcacf/openai-2.31.0.tar.gz", hash = "sha256:43ca59a88fc973ad1848d86b98d7fac207e265ebbd1828b5e4bdfc85f79427a5", size = 684772, upload-time = "2026-04-08T21:01:41.797Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/bc/a8f7c3aa03452fedbb9af8be83e959adba96a6b4a35e416faffcc959c568/openai-2.31.0-py3-none-any.whl", hash = "sha256:44e1344d87e56a493d649b17e2fac519d1368cbb0745f59f1957c4c26de50a0a", size = 1153479, upload-time = "2026-04-08T21:01:39.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
 ]
 
 [[package]]
@@ -1525,6 +1552,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1550,6 +1591,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/e7/ebb504fee5dac9710192ca04550e8c8250bb2a7612a2397829e3934eb157/resend-2.29.0.tar.gz", hash = "sha256:cd905809a64128b29d5beda1d4a5bda8d60d438a66942ed736ca40238e9d2331", size = 43125, upload-time = "2026-04-16T13:14:56.183Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/91/9299b0eac66a33d48dea8c825063077f28d188d89b2d3178c3837c40b3df/resend-2.29.0-py2.py3-none-any.whl", hash = "sha256:aad7c6097c26cf2dbe46534a1fc8d92637fbdea28243b00a3363c8d3136331de", size = 68320, upload-time = "2026-04-16T13:14:54.928Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]
@@ -1617,14 +1739,15 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "jsonschema" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "alembic", specifier = ">=1.13.0" },
-    { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "alembic", specifier = ">=1.18.4" },
+    { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "bcrypt", specifier = "<4.1" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "celery", extras = ["redis"], specifier = ">=5.4.0" },
@@ -1633,8 +1756,9 @@ requires-dist = [
     { name = "groq", specifier = ">=0.9.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.23.0" },
     { name = "numpy", specifier = ">=2.0.0,<3" },
-    { name = "openai", specifier = ">=2.31.0" },
+    { name = "openai", specifier = ">=2.32.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pgvector", specifier = ">=0.4.0,<0.5" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },

--- a/docs/phase-2-6/implementation.md
+++ b/docs/phase-2-6/implementation.md
@@ -1,0 +1,2514 @@
+# Sonar Phase 2.6 — Fit × Intent Hybrid Scoring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Status:** Ready to execute (design approved — see `docs/phase-2-6/design.md`)
+**Date:** 2026-04-20 (written end-of-session-9)
+**Supersedes:** Narrow "threshold calibration" framing from issue #106
+
+**Goal:** Replace Sonar's single-axis post-similarity matching (`combined_score`) with a two-axis hybrid that multiplies a per-connection **fit_score** (is this author a buyer?) by a per-post **intent_score** (does this post show intent?). Fix the Lipi Mittal / NotifyVisitors class of failure proven by the session-8 calibration evidence.
+
+**Architecture:** For each connection, compute `fit_score = cos(ICP, connection) - λ·cos(seller_mirror, connection)` where ICP and seller-mirror are LLM-extracted from the workspace URL/doc/text. For each post, compute `intent_score` from relevance + timing (relationship removed — moves to dashboard filter). Combine multiplicatively: `final_score = fit_score × intent_score`. Ship behind `workspace.use_hybrid_scoring` feature flag; existing workspaces stay on the old scorer until explicitly flipped.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2 async + Alembic + pgvector + OpenAI (`text-embedding-3-small` + `gpt-5.4-mini`) + Celery + pytest. Frontend: React 18 + TypeScript + Vite + React Router v6.
+
+---
+
+## Pre-flight for every task
+
+Every backend command runs inside the `api` container. Reminders:
+
+```bash
+docker compose up -d postgres redis api                 # stack up
+docker compose exec -T api alembic upgrade head         # latest migrations
+docker compose exec -T api pytest -q                    # baseline: all 136 pass
+```
+
+Never `cd backend && uv run ...` — the host has no `uv`/Python.
+
+Branch discipline: each task is its own feature branch + PR, per Sonar's CLAUDE.md "Complex changes" rule. Branch prefix `feat/phase-2-6-<slice>`. Dispatch `superpowers:code-reviewer` before opening every PR; wait for approval before merging. No exceptions.
+
+---
+
+## File Structure
+
+New files:
+
+```
+backend/alembic/versions/
+  008_connection_fit_score.py             # ADD fit_score to connections
+  009_workspace_use_hybrid_scoring.py     # ADD use_hybrid_scoring flag
+  010_icp_and_seller_mirror.py            # ADD icp, seller_mirror, their embeddings
+
+backend/app/prompts/
+  extract_icp_and_seller_mirror.py        # Single dual-output prompt
+
+backend/app/services/
+  fit_scorer.py                           # compute_fit_score, compute_intent_score, compute_hybrid_score
+
+backend/scripts/
+  backfill_fit_scores.py                  # One-shot per-workspace fit_score backfill
+
+backend/tests/
+  test_migration_008_009_010.py           # Migration round-trip test
+  test_extract_icp_prompt.py              # Prompt module unit test
+  test_fit_scorer.py                      # Fit scorer unit tests
+  test_profile_extract_icp.py             # /profile/extract integration test (ICP path)
+  test_pipeline_hybrid_scoring.py         # Pipeline branch integration test
+  test_backfill_fit_scores.py             # Backfill script integration test
+  test_calibrate_hybrid.py                # analyze-hybrid subcommand unit test
+```
+
+Modified files:
+
+```
+backend/app/models/workspace.py           # +use_hybrid_scoring, +icp, +seller_mirror, +embeddings
+backend/app/models/connection.py          # +fit_score
+backend/app/services/profile_extractor.py # Extract & persist ICP + seller_mirror
+backend/app/routers/profile.py            # Return icp/seller_mirror in response
+backend/app/workers/pipeline.py           # Branch on use_hybrid_scoring
+backend/scripts/calibrate_matching.py     # +analyze-hybrid subcommand w/ λ sweep
+frontend/src/pages/SignalConfig.tsx       # +ICP review step (insert as step 3; renumber)
+```
+
+---
+
+## Task 1: Migrations 008+009+010 + ORM model updates
+
+Adds all three schema additions in one PR. They're independent and all additive, so one migration-bundle PR avoids three back-to-back review cycles for trivial DDL.
+
+**Files:**
+- Create: `backend/alembic/versions/008_connection_fit_score.py`
+- Create: `backend/alembic/versions/009_workspace_use_hybrid_scoring.py`
+- Create: `backend/alembic/versions/010_icp_and_seller_mirror.py`
+- Modify: `backend/app/models/connection.py` — add `fit_score` column
+- Modify: `backend/app/models/workspace.py` — add `use_hybrid_scoring` to Workspace, add `icp`/`seller_mirror`/`icp_embedding`/`seller_mirror_embedding` to CapabilityProfileVersion
+- Test: `backend/tests/test_migration_008_009_010.py`
+
+Branch: `feat/phase-2-6-migrations`
+
+- [ ] **Step 1: Write the failing round-trip migration test**
+
+Create `backend/tests/test_migration_008_009_010.py`:
+
+```python
+"""Round-trip test: head → 007 → head works without errors and preserves row counts."""
+import pytest
+from sqlalchemy import text
+from alembic import command
+from alembic.config import Config
+
+
+@pytest.fixture
+def alembic_cfg() -> Config:
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("script_location", "alembic")
+    return cfg
+
+
+def test_migrations_008_009_010_round_trip(alembic_cfg: Config):
+    """Upgrade to head, downgrade to 007, upgrade to head. Should not error."""
+    command.upgrade(alembic_cfg, "head")
+    command.downgrade(alembic_cfg, "007")
+    command.upgrade(alembic_cfg, "head")
+
+
+def test_new_columns_present_after_upgrade(alembic_cfg: Config, sync_engine):
+    """After head, the 6 new columns exist with correct types and defaults."""
+    command.upgrade(alembic_cfg, "head")
+    with sync_engine.connect() as conn:
+        # Migration 008
+        row = conn.execute(text(
+            "SELECT column_name, data_type, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_name='connections' AND column_name='fit_score'"
+        )).fetchone()
+        assert row is not None, "connections.fit_score missing"
+        assert row.data_type == "real"
+        assert row.is_nullable == "YES"
+
+        # Migration 009
+        row = conn.execute(text(
+            "SELECT column_name, data_type, is_nullable, column_default "
+            "FROM information_schema.columns "
+            "WHERE table_name='workspaces' AND column_name='use_hybrid_scoring'"
+        )).fetchone()
+        assert row is not None, "workspaces.use_hybrid_scoring missing"
+        assert row.data_type == "boolean"
+        assert row.is_nullable == "NO"
+        assert "false" in (row.column_default or "").lower()
+
+        # Migration 010
+        for col in ("icp", "seller_mirror", "icp_embedding", "seller_mirror_embedding"):
+            row = conn.execute(text(
+                "SELECT column_name FROM information_schema.columns "
+                f"WHERE table_name='capability_profile_versions' AND column_name='{col}'"
+            )).fetchone()
+            assert row is not None, f"capability_profile_versions.{col} missing"
+```
+
+Note: `sync_engine` fixture may not exist yet. If it doesn't, add it to `conftest.py`:
+
+```python
+@pytest.fixture
+def sync_engine():
+    """Synchronous engine for DDL introspection. Separate from the async test engine."""
+    from sqlalchemy import create_engine
+    from app.config import get_settings
+    url = get_settings().database_url.replace("+asyncpg", "")
+    engine = create_engine(url)
+    yield engine
+    engine.dispose()
+```
+
+- [ ] **Step 2: Run the test — it must fail**
+
+```bash
+docker compose exec -T api pytest tests/test_migration_008_009_010.py -v
+```
+
+Expected: FAIL — migrations 008/009/010 don't exist yet. Error mentions "Can't locate revision 008" or similar.
+
+- [ ] **Step 3: Write migration 008**
+
+Create `backend/alembic/versions/008_connection_fit_score.py`:
+
+```python
+"""Add fit_score to connections (Phase 2.6).
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-04-20
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "008"
+down_revision = "007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "connections",
+        sa.Column("fit_score", sa.REAL(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("connections", "fit_score")
+```
+
+- [ ] **Step 4: Write migration 009**
+
+Create `backend/alembic/versions/009_workspace_use_hybrid_scoring.py`:
+
+```python
+"""Add use_hybrid_scoring flag to workspaces (Phase 2.6).
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-04-20
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "use_hybrid_scoring",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "use_hybrid_scoring")
+```
+
+- [ ] **Step 5: Write migration 010**
+
+Create `backend/alembic/versions/010_icp_and_seller_mirror.py`:
+
+```python
+"""Add icp, seller_mirror, and their embeddings to capability_profile_versions (Phase 2.6).
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-04-20
+"""
+from alembic import op
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+
+revision = "010"
+down_revision = "009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("capability_profile_versions", sa.Column("icp", sa.Text(), nullable=True))
+    op.add_column("capability_profile_versions", sa.Column("seller_mirror", sa.Text(), nullable=True))
+    op.add_column("capability_profile_versions", sa.Column("icp_embedding", Vector(1536), nullable=True))
+    op.add_column("capability_profile_versions", sa.Column("seller_mirror_embedding", Vector(1536), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("capability_profile_versions", "seller_mirror_embedding")
+    op.drop_column("capability_profile_versions", "icp_embedding")
+    op.drop_column("capability_profile_versions", "seller_mirror")
+    op.drop_column("capability_profile_versions", "icp")
+```
+
+- [ ] **Step 6: Update Connection ORM model**
+
+Modify `backend/app/models/connection.py` — add to the Connection class (place next to `relationship_score`):
+
+```python
+    fit_score = Column(Float, nullable=True)
+```
+
+- [ ] **Step 7: Update Workspace ORM model**
+
+Modify `backend/app/models/workspace.py` — add to the Workspace class (place next to `matching_threshold`):
+
+```python
+    use_hybrid_scoring = Column(Boolean, nullable=False, default=False, server_default="false")
+```
+
+And add to the CapabilityProfileVersion class (place after `anti_keywords`):
+
+```python
+    icp = Column(Text, nullable=True)
+    seller_mirror = Column(Text, nullable=True)
+    icp_embedding = Column(Vector(1536), nullable=True)
+    seller_mirror_embedding = Column(Vector(1536), nullable=True)
+```
+
+Confirm imports in the file — `Vector` should already be imported for the existing `embedding` column. If not:
+
+```python
+from pgvector.sqlalchemy import Vector
+```
+
+- [ ] **Step 8: Run the migration round-trip test — must pass**
+
+```bash
+docker compose exec -T api alembic downgrade base    # fresh start
+docker compose exec -T api pytest tests/test_migration_008_009_010.py -v
+```
+
+Expected: 2 passed. If the round-trip fails with "relation already exists," the downgrade path is missing a column.
+
+- [ ] **Step 9: Run the full test suite — must pass (regression check)**
+
+```bash
+docker compose exec -T api pytest -q
+```
+
+Expected: 136 + 2 new = 138 passed (or same "5 passing pre-existing failures" baseline from CLAUDE.md).
+
+- [ ] **Step 10: Verify manually via psql**
+
+```bash
+docker compose exec -T postgres psql -U sonar -d sonar -c "\d connections"
+docker compose exec -T postgres psql -U sonar -d sonar -c "\d workspaces"
+docker compose exec -T postgres psql -U sonar -d sonar -c "\d capability_profile_versions"
+```
+
+Each should list the new columns.
+
+- [ ] **Step 11: Dispatch `superpowers:code-reviewer`**
+
+Open a review request against the branch diff. Spec compliance check: migrations match design §4.2 "Schema changes (three non-breaking migrations)." Code quality check: ORM models mirror migrations, no accidental defaults, no broken relationships.
+
+- [ ] **Step 12: Commit and open PR**
+
+```bash
+git checkout -b feat/phase-2-6-migrations
+git add backend/alembic/versions/008_connection_fit_score.py \
+        backend/alembic/versions/009_workspace_use_hybrid_scoring.py \
+        backend/alembic/versions/010_icp_and_seller_mirror.py \
+        backend/app/models/connection.py \
+        backend/app/models/workspace.py \
+        backend/tests/test_migration_008_009_010.py \
+        backend/tests/conftest.py
+git commit -m "feat(db): add Phase 2.6 migrations 008/009/010 + ORM updates
+
+- connections.fit_score REAL NULL
+- workspaces.use_hybrid_scoring BOOLEAN NOT NULL DEFAULT FALSE
+- capability_profile_versions.icp TEXT NULL + embedding
+- capability_profile_versions.seller_mirror TEXT NULL + embedding
+
+All additive. Existing rows keep current behavior until explicitly flipped.
+Part of Phase 2.6 — see docs/phase-2-6/design.md §4.2."
+git push -u origin feat/phase-2-6-migrations
+gh pr create --title "feat(db): Phase 2.6 migrations 008/009/010" \
+             --body "$(cat <<'EOF'
+## Summary
+Schema additions for Phase 2.6 Fit × Intent hybrid scoring:
+- Migration 008 — `connections.fit_score REAL NULL`
+- Migration 009 — `workspaces.use_hybrid_scoring BOOLEAN DEFAULT FALSE`
+- Migration 010 — `capability_profile_versions.{icp, seller_mirror, icp_embedding, seller_mirror_embedding}`
+
+All three are additive with safe defaults. Zero breaking changes; every existing workspace continues running the existing scorer until explicitly flipped via the flag.
+
+## Test plan
+- [x] Round-trip test (head → 007 → head) passes
+- [x] New-column introspection test passes
+- [x] Full backend suite still green
+- [ ] Reviewer verifies `upgrade()` / `downgrade()` symmetry
+EOF
+)"
+```
+
+---
+
+## Task 2: ICP + seller_mirror prompt module
+
+A single dual-output prompt module, following the `propose_signals.py` pattern. Lives under `app/prompts/` with its own `PROMPT_VERSION` so changes are auditable.
+
+**Files:**
+- Create: `backend/app/prompts/extract_icp_and_seller_mirror.py`
+- Test: `backend/tests/test_extract_icp_prompt.py`
+
+Branch: `feat/phase-2-6-icp-prompt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_extract_icp_prompt.py`:
+
+```python
+"""Prompt module: structure + schema validation.
+
+This file does NOT test LLM output quality (that's for calibration), only that
+the prompt module is well-formed: version set, system prompt static, user
+message builder interpolates the right inputs, schema validates realistic JSON.
+"""
+import json
+import pytest
+from jsonschema import validate, ValidationError
+
+from app.prompts import extract_icp_and_seller_mirror as mod
+
+
+def test_prompt_version_is_semver_like():
+    assert isinstance(mod.PROMPT_VERSION, str)
+    assert mod.PROMPT_VERSION.startswith("v")
+
+
+def test_system_prompt_is_static_and_nonempty():
+    assert isinstance(mod.SYSTEM_PROMPT, str)
+    assert len(mod.SYSTEM_PROMPT) > 100
+    # Must not contain user-controlled placeholders
+    assert "{" not in mod.SYSTEM_PROMPT
+    assert "}" not in mod.SYSTEM_PROMPT
+
+
+def test_build_user_message_interpolates_source_text():
+    source = "We sell CDP tooling for D2C brands."
+    msg = mod.build_user_message(source_text=source)
+    assert source in msg
+
+
+def test_build_user_message_rejects_empty():
+    with pytest.raises(ValueError):
+        mod.build_user_message(source_text="")
+
+
+def test_response_schema_validates_well_formed_output():
+    sample = {
+        "icp": "Marketing, growth, or e-commerce leaders at D2C or direct-to-consumer brands generating >$1M ARR. Not employees of martech SaaS vendors or competing agencies.",
+        "seller_mirror": "Founders, CEOs, CPOs, and sales directors at CDP / marketing-automation / customer-engagement SaaS companies. People whose LinkedIn headlines name-drop their own product.",
+    }
+    validate(instance=sample, schema=mod.RESPONSE_JSON_SCHEMA)
+
+
+def test_response_schema_rejects_missing_field():
+    sample = {"icp": "..."}  # missing seller_mirror
+    with pytest.raises(ValidationError):
+        validate(instance=sample, schema=mod.RESPONSE_JSON_SCHEMA)
+
+
+def test_response_schema_rejects_short_fields():
+    sample = {"icp": "short", "seller_mirror": "also short"}
+    with pytest.raises(ValidationError):
+        validate(instance=sample, schema=mod.RESPONSE_JSON_SCHEMA)
+```
+
+- [ ] **Step 2: Run the test — must fail**
+
+```bash
+docker compose exec -T api pytest tests/test_extract_icp_prompt.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: extract_icp_and_seller_mirror`.
+
+- [ ] **Step 3: Write the prompt module**
+
+Create `backend/app/prompts/extract_icp_and_seller_mirror.py`:
+
+```python
+"""Extract ICP paragraph + seller-mirror paragraph from a workspace's source text.
+
+Single dual-output prompt per design §3.2 and §8. Outputs are consumed by
+profile_extractor to persist icp / seller_mirror text + embeddings on
+capability_profile_versions.
+
+PROMPT_VERSION: bump on every content change. Logged alongside every call.
+"""
+
+PROMPT_VERSION = "v1"
+
+SYSTEM_PROMPT = """You are a B2B sales intelligence analyst. Given a company's
+self-description (from their website, a sales playbook, or a typed summary),
+your job is to produce two paragraphs that describe (a) who that company's
+buyers are and (b) what OTHER companies that sell the SAME capability look
+like on LinkedIn.
+
+Rules for the ICP paragraph:
+1. Name the buyer's role, seniority, and company shape (industry, stage, size).
+2. Phrase contrastively — explicitly name who the buyer is NOT. Example: "Not
+   employees of martech SaaS vendors or competing agencies."
+3. Written in plain English. No bullet lists, no headers. One dense paragraph.
+4. 50-120 words.
+
+Rules for the seller-mirror paragraph:
+1. Describe what other SELLERS of this same capability look like on LinkedIn.
+   Who would a competitor's founder, CEO, CPO, or sales director look like?
+2. Focus on linguistic tells in LinkedIn headlines — product name-drops,
+   stage signals ("Series B", "YC W22"), role words ("CEO", "Founder",
+   "Head of Sales at X").
+3. This paragraph is SUBTRACTED from the ICP signal during scoring, so
+   precision matters: describe the seller-shape as specifically as you can.
+4. 50-120 words.
+
+Return strict JSON with exactly two keys: icp and seller_mirror. No other keys,
+no prose outside the JSON."""
+
+
+def build_user_message(source_text: str) -> str:
+    """Compose the user turn. This is the only place user input is interpolated.
+
+    Raises ValueError if source_text is empty or whitespace-only.
+    """
+    if not source_text or not source_text.strip():
+        raise ValueError("source_text must be non-empty")
+    return (
+        "Here is the company's self-description. Produce the ICP and seller-mirror "
+        "paragraphs per the rules.\n\n"
+        "---\n"
+        f"{source_text.strip()}\n"
+        "---"
+    )
+
+
+RESPONSE_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "icp": {
+            "type": "string",
+            "minLength": 80,
+            "maxLength": 1200,
+        },
+        "seller_mirror": {
+            "type": "string",
+            "minLength": 80,
+            "maxLength": 1200,
+        },
+    },
+    "required": ["icp", "seller_mirror"],
+    "additionalProperties": False,
+}
+```
+
+- [ ] **Step 4: Run the test — must pass**
+
+```bash
+docker compose exec -T api pytest tests/test_extract_icp_prompt.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Run full suite — must still pass**
+
+```bash
+docker compose exec -T api pytest -q
+```
+
+- [ ] **Step 6: Dispatch `superpowers:code-reviewer`**
+
+Spec compliance: matches design §3.2 "ICP paragraph: contrastive phrasing" + "Seller-mirror paragraph: linguistic mirror." Code quality: no user-input interpolation into SYSTEM_PROMPT, schema has `additionalProperties: false`, min/max bounds reasonable.
+
+- [ ] **Step 7: Commit + PR**
+
+```bash
+git checkout -b feat/phase-2-6-icp-prompt
+git add backend/app/prompts/extract_icp_and_seller_mirror.py \
+        backend/tests/test_extract_icp_prompt.py
+git commit -m "feat(prompts): add extract_icp_and_seller_mirror prompt module
+
+Single dual-output prompt producing an ICP paragraph + seller-mirror
+paragraph from a workspace's source text. Consumed by profile_extractor
+(Task 4) to populate capability_profile_versions.icp and .seller_mirror.
+
+PROMPT_VERSION=v1. Contrastive ICP phrasing + explicit seller-shape
+description per design §3.2."
+git push -u origin feat/phase-2-6-icp-prompt
+gh pr create --title "feat(prompts): ICP + seller-mirror extraction prompt" \
+             --body "$(cat <<'EOF'
+## Summary
+- New prompt module: `app/prompts/extract_icp_and_seller_mirror.py`
+- Dual-output: `{ icp, seller_mirror }` JSON
+- Follows the `propose_signals.py` convention (PROMPT_VERSION, static SYSTEM_PROMPT, `build_user_message()` only place user input is interpolated, `RESPONSE_JSON_SCHEMA` for validation)
+
+## Test plan
+- [x] 6 unit tests pass (version set, system prompt static, user builder validates, schema validates well-formed output and rejects malformed)
+- [x] Full suite still green
+EOF
+)"
+```
+
+---
+
+## Task 3: Fit scorer service
+
+Pure-function scoring module. No DB, no LLM. Easy to test. Defines `compute_fit_score`, `compute_intent_score`, `compute_hybrid_score`.
+
+Key implementation decision: **floor `fit_score` at 0.0**. If `cos(icp) - λ·cos(mirror)` goes negative (connection looks more like a seller than a buyer), clamp to 0. Multiplying a negative fit by a positive intent would give negative final_score and invert ordering — not the intended behavior. Flooring at 0 means anti-ICP connections get `final_score = 0` (correct suppression).
+
+**Files:**
+- Create: `backend/app/services/fit_scorer.py`
+- Test: `backend/tests/test_fit_scorer.py`
+
+Branch: `feat/phase-2-6-fit-scorer`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/test_fit_scorer.py`:
+
+```python
+"""Unit tests for fit_scorer — pure math, no DB, no LLM."""
+from datetime import datetime, timedelta, timezone
+import math
+
+import pytest
+
+from app.services.fit_scorer import (
+    cosine_similarity,
+    compute_fit_score,
+    compute_intent_score,
+    compute_hybrid_score,
+)
+
+
+# ---------- cosine_similarity ----------
+
+def test_cosine_similarity_identical_vectors():
+    v = [1.0, 0.0, 0.0]
+    assert math.isclose(cosine_similarity(v, v), 1.0)
+
+
+def test_cosine_similarity_orthogonal_vectors():
+    assert math.isclose(cosine_similarity([1.0, 0.0], [0.0, 1.0]), 0.0)
+
+
+def test_cosine_similarity_opposite_vectors():
+    assert math.isclose(cosine_similarity([1.0, 0.0], [-1.0, 0.0]), -1.0)
+
+
+def test_cosine_similarity_zero_vector_returns_zero():
+    assert cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+# ---------- compute_fit_score ----------
+
+def test_fit_score_pure_icp_match_no_seller_signal():
+    # ICP matches perfectly; seller signal absent
+    icp_emb = [1.0, 0.0, 0.0]
+    mirror_emb = [0.0, 1.0, 0.0]
+    conn_emb = [1.0, 0.0, 0.0]  # perfect ICP, zero seller
+    fit = compute_fit_score(icp_emb, mirror_emb, conn_emb, lambda_=0.3)
+    assert math.isclose(fit, 1.0, abs_tol=1e-6)
+
+
+def test_fit_score_pure_seller_match_floored_at_zero():
+    # Connection is a perfect seller mirror, nothing like ICP
+    icp_emb = [1.0, 0.0, 0.0]
+    mirror_emb = [0.0, 1.0, 0.0]
+    conn_emb = [0.0, 1.0, 0.0]  # perfect mirror → raw = 0 - 0.3*1 = -0.3
+    fit = compute_fit_score(icp_emb, mirror_emb, conn_emb, lambda_=0.3)
+    assert fit == 0.0, "negative raw fit must floor at 0"
+
+
+def test_fit_score_lambda_zero_equals_raw_icp_cosine():
+    icp_emb = [1.0, 0.0, 0.0]
+    mirror_emb = [0.0, 1.0, 0.0]
+    conn_emb = [0.8, 0.6, 0.0]
+    expected = cosine_similarity(icp_emb, conn_emb)  # 0.8
+    assert math.isclose(
+        compute_fit_score(icp_emb, mirror_emb, conn_emb, lambda_=0.0),
+        expected, abs_tol=1e-6,
+    )
+
+
+def test_fit_score_lambda_one_subtracts_full_mirror_term():
+    icp_emb = [1.0, 0.0, 0.0]
+    mirror_emb = [0.0, 1.0, 0.0]
+    conn_emb = [0.8, 0.6, 0.0]
+    # raw = 0.8 - 1.0*0.6 = 0.2
+    assert math.isclose(
+        compute_fit_score(icp_emb, mirror_emb, conn_emb, lambda_=1.0),
+        0.2, abs_tol=1e-6,
+    )
+
+
+def test_fit_score_dimension_mismatch_raises():
+    with pytest.raises(ValueError):
+        compute_fit_score([1.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0], lambda_=0.3)
+
+
+def test_fit_score_negative_lambda_raises():
+    with pytest.raises(ValueError):
+        compute_fit_score([1.0], [0.5], [1.0], lambda_=-0.1)
+
+
+# ---------- compute_intent_score ----------
+
+def test_intent_score_fresh_post_full_relevance():
+    now = datetime.now(timezone.utc)
+    score = compute_intent_score(relevance_score=1.0, posted_at=now)
+    assert math.isclose(score, 1.0, abs_tol=1e-3)  # 0.7*1 + 0.3*1 = 1
+
+
+def test_intent_score_stale_post_timing_decayed_to_zero():
+    then = datetime.now(timezone.utc) - timedelta(hours=48)
+    score = compute_intent_score(relevance_score=1.0, posted_at=then)
+    # relevance 1 * 0.7 + timing 0 * 0.3 = 0.7
+    assert math.isclose(score, 0.7, abs_tol=1e-3)
+
+
+def test_intent_score_mid_decay():
+    then = datetime.now(timezone.utc) - timedelta(hours=12)
+    score = compute_intent_score(relevance_score=0.5, posted_at=then)
+    # relevance 0.5 * 0.7 + timing 0.5 * 0.3 = 0.35 + 0.15 = 0.5
+    assert math.isclose(score, 0.5, abs_tol=1e-2)
+
+
+def test_intent_score_clamped_to_unit_interval():
+    now = datetime.now(timezone.utc)
+    assert 0.0 <= compute_intent_score(relevance_score=0.0, posted_at=now) <= 1.0
+    assert 0.0 <= compute_intent_score(relevance_score=1.5, posted_at=now) <= 1.0
+
+
+# ---------- compute_hybrid_score ----------
+
+def test_hybrid_score_multiplies_fit_and_intent():
+    assert math.isclose(compute_hybrid_score(fit_score=0.4, intent_score=0.9), 0.36)
+
+
+def test_hybrid_score_zero_fit_suppresses():
+    """The Lipi Mittal fix: low fit zeros out regardless of intent."""
+    assert compute_hybrid_score(fit_score=0.0, intent_score=0.95) == 0.0
+
+
+def test_hybrid_score_zero_intent_suppresses():
+    assert compute_hybrid_score(fit_score=0.8, intent_score=0.0) == 0.0
+
+
+def test_hybrid_score_clamps_to_unit_interval():
+    assert compute_hybrid_score(fit_score=1.0, intent_score=1.0) == 1.0
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+docker compose exec -T api pytest tests/test_fit_scorer.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: app.services.fit_scorer`.
+
+- [ ] **Step 3: Write the fit_scorer module**
+
+Create `backend/app/services/fit_scorer.py`:
+
+```python
+"""Fit × Intent hybrid scoring — Phase 2.6.
+
+Pure functions. No DB, no LLM, no async. Import-safe from workers and scripts.
+
+Design reference: docs/phase-2-6/design.md §3.2, §3.5.
+"""
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Sequence
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity in [-1, 1]. Returns 0.0 if either vector is zero."""
+    if len(a) != len(b):
+        raise ValueError(f"dimension mismatch: {len(a)} vs {len(b)}")
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def compute_fit_score(
+    icp_embedding: Sequence[float],
+    seller_mirror_embedding: Sequence[float],
+    connection_embedding: Sequence[float],
+    lambda_: float,
+) -> float:
+    """fit_score = max(0, cos(ICP, conn) - λ·cos(seller_mirror, conn)).
+
+    Floored at 0: anti-ICP connections (raw < 0) get suppressed to 0, not
+    ranked negatively. Multiplying a negative fit by a positive intent
+    would invert ordering — not the intended behavior.
+
+    Raises ValueError on negative lambda_ or mismatched dimensions.
+    """
+    if lambda_ < 0:
+        raise ValueError(f"lambda_ must be non-negative, got {lambda_}")
+    if not (len(icp_embedding) == len(seller_mirror_embedding) == len(connection_embedding)):
+        raise ValueError("all three embeddings must share dimension")
+
+    icp_cos = cosine_similarity(icp_embedding, connection_embedding)
+    mirror_cos = cosine_similarity(seller_mirror_embedding, connection_embedding)
+    raw = icp_cos - lambda_ * mirror_cos
+    return max(0.0, raw)
+
+
+def compute_intent_score(
+    relevance_score: float,
+    posted_at: datetime,
+    *,
+    now: datetime | None = None,
+) -> float:
+    """intent_score = 0.7·relevance + 0.3·timing. No relationship axis.
+
+    Relationship moves to the dashboard degree filter per design §3.5.
+    Timing decays linearly to 0 over 24 hours.
+    """
+    now = now or datetime.now(timezone.utc)
+    # Ensure posted_at is timezone-aware
+    if posted_at.tzinfo is None:
+        posted_at = posted_at.replace(tzinfo=timezone.utc)
+    hours_old = max(0.0, (now - posted_at).total_seconds() / 3600.0)
+    timing = max(0.0, 1.0 - hours_old / 24.0)
+    relevance = max(0.0, min(1.0, relevance_score))
+    return max(0.0, min(1.0, 0.7 * relevance + 0.3 * timing))
+
+
+def compute_hybrid_score(fit_score: float, intent_score: float) -> float:
+    """final_score = fit_score × intent_score, clamped to [0, 1]."""
+    return max(0.0, min(1.0, fit_score * intent_score))
+```
+
+- [ ] **Step 4: Run tests — must pass**
+
+```bash
+docker compose exec -T api pytest tests/test_fit_scorer.py -v
+```
+
+Expected: 15 passed.
+
+- [ ] **Step 5: Run full suite — must stay green**
+
+```bash
+docker compose exec -T api pytest -q
+```
+
+- [ ] **Step 6: Dispatch `superpowers:code-reviewer`**
+
+Spec compliance: formula matches design §3.2, flooring decision is explicit. Code quality: pure functions, input validation, docstrings point at the design doc.
+
+- [ ] **Step 7: Commit + PR**
+
+```bash
+git checkout -b feat/phase-2-6-fit-scorer
+git add backend/app/services/fit_scorer.py backend/tests/test_fit_scorer.py
+git commit -m "feat(scoring): add fit_scorer service for Phase 2.6 hybrid scoring
+
+Pure functions implementing the Fit × Intent math from design §3.2 + §3.5:
+
+- compute_fit_score = max(0, cos(ICP, conn) - λ·cos(mirror, conn))
+- compute_intent_score = 0.7·relevance + 0.3·timing (no relationship axis)
+- compute_hybrid_score = fit × intent, clamped [0, 1]
+
+Flooring fit_score at 0 handles the negative-raw-fit case: anti-ICP
+connections suppress to 0 rather than ranking negatively.
+
+15 unit tests. No DB, no LLM, no async."
+git push -u origin feat/phase-2-6-fit-scorer
+gh pr create --title "feat(scoring): Phase 2.6 fit_scorer service" \
+             --body "$(cat <<'EOF'
+## Summary
+Pure-function scoring module for Phase 2.6. Consumed by the pipeline branch
+(Task 5) and the backfill script (Task 6).
+
+Key design decision made in implementation: **floor `fit_score` at 0**. Design
+§3.2 doesn't explicitly specify behavior when `cos(ICP) - λ·cos(mirror)` goes
+negative. I chose clamp-to-zero because:
+- Multiplying negative fit by positive intent inverts ordering (wrong)
+- Anti-ICP connections should suppress to 0, not rank negatively
+- Calibration sweeps over λ will never produce a legitimate negative final_score
+
+Flagging in the PR so reviewer can agree/overrule before this locks in.
+
+## Test plan
+- [x] 15 unit tests cover cosine edge cases, lambda bounds, intent timing decay, hybrid combine + clamp
+- [x] Full suite green
+EOF
+)"
+```
+
+---
+
+## Task 4: Extend profile_extractor + `/profile/extract` endpoint
+
+Add ICP + seller_mirror extraction to the existing capability-profile extraction flow. Persist both text fields + both embeddings on `capability_profile_versions`. Extend the response model so the frontend can display them.
+
+**Files:**
+- Modify: `backend/app/services/profile_extractor.py` — add ICP + seller_mirror extraction
+- Modify: `backend/app/routers/profile.py` — extend response model, pass embeddings through
+- Test: `backend/tests/test_profile_extract_icp.py`
+
+Branch: `feat/phase-2-6-profile-extract-icp`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `backend/tests/test_profile_extract_icp.py`:
+
+```python
+"""Integration test: POST /profile/extract persists ICP + seller_mirror."""
+import json
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.workspace import CapabilityProfileVersion, Workspace
+
+
+class _FakeLLMForICP:
+    """Returns capability JSON first, then ICP+mirror JSON."""
+    def __init__(self):
+        self.calls = []
+
+    async def complete(self, prompt, model=None, *, system=None, max_tokens=2048):
+        self.calls.append(("complete", system, prompt[:60]))
+        if "sales intelligence analyst" in (system or "").lower():
+            # ICP prompt
+            return json.dumps({
+                "icp": "Marketing and growth leaders at D2C brands. Not competing martech vendors or agency employees. Must own a budget for outbound tooling.",
+                "seller_mirror": "Founders, CEOs, CPOs at CDP or marketing-automation SaaS companies. LinkedIn headlines typically name-drop the product and include Series A/B signals.",
+            })
+        # Capability prompt (existing path)
+        return json.dumps({
+            "company_name": "Acme CDP",
+            "capability_summary": "We sell a CDP for D2C brands.",
+            "signal_keywords": ["customer data", "cdp migration"],
+        })
+
+
+class _FakeEmbedding:
+    async def embed(self, text: str) -> list[float]:
+        # Deterministic fake embedding keyed by first char, so we can distinguish
+        # ICP / seller_mirror / capability in assertions
+        seed = ord(text[0]) if text else 0
+        return [float((seed + i) % 10) / 10.0 for i in range(1536)]
+
+
+@pytest.mark.asyncio
+async def test_profile_extract_persists_icp_and_seller_mirror(
+    client: AsyncClient,
+    db_session,
+    auth_headers,
+    workspace_id,
+):
+    from app.main import app
+    from app.services.embedding import get_embedding_provider
+    from app.services.llm import get_llm_client
+
+    fake_llm = _FakeLLMForICP()
+    fake_emb = _FakeEmbedding()
+    app.dependency_overrides[get_llm_client] = lambda: fake_llm
+    app.dependency_overrides[get_embedding_provider] = lambda: fake_emb
+
+    try:
+        resp = await client.post(
+            "/profile/extract",
+            json={"text": "Acme CDP sells customer-data tooling to D2C brands."},
+            headers=auth_headers,
+        )
+    finally:
+        app.dependency_overrides.pop(get_llm_client, None)
+        app.dependency_overrides.pop(get_embedding_provider, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["icp"].startswith("Marketing")
+    assert body["seller_mirror"].startswith("Founders")
+
+    row = (await db_session.execute(
+        select(CapabilityProfileVersion)
+        .where(CapabilityProfileVersion.workspace_id == workspace_id)
+        .where(CapabilityProfileVersion.is_active.is_(True))
+    )).scalar_one()
+
+    assert row.icp is not None and "D2C" in row.icp
+    assert row.seller_mirror is not None and "CDP" in row.seller_mirror
+    assert row.icp_embedding is not None
+    assert len(list(row.icp_embedding)) == 1536
+    assert row.seller_mirror_embedding is not None
+    assert len(list(row.seller_mirror_embedding)) == 1536
+```
+
+`auth_headers` and `workspace_id` fixtures do not exist in conftest.py yet. Add both to `backend/tests/conftest.py` (verified absent; no duplication risk). Use the simpler "override `get_current_user`" pattern instead of minting a real JWT — it's cheaper, avoids hashing a test password, and works for any test that needs an authenticated request:
+
+```python
+@pytest_asyncio.fixture
+async def workspace_id(db_session):
+    """Create a test workspace and return its UUID."""
+    from app.models.workspace import Workspace
+    ws = Workspace(name="Test WS", plan_tier="starter")
+    db_session.add(ws)
+    await db_session.flush()
+    return ws.id
+
+
+@pytest_asyncio.fixture
+async def auth_headers(workspace_id, db_session):
+    """Install a dependency override for get_current_user that returns a fake
+    User bound to `workspace_id`, and return an empty headers dict.
+
+    Tests do: `await client.post('/x', json=..., headers=auth_headers)`.
+    The override is cleared by the `client` fixture's `app.dependency_overrides.clear()`
+    at teardown, so no leak between tests.
+    """
+    from app.main import app
+    from app.routers.auth import get_current_user
+    from app.models.user import User
+
+    user = User(
+        email="test@example.com",
+        password_hash="x",  # not used — auth is overridden
+        workspace_id=workspace_id,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    async def _override():
+        return user
+
+    app.dependency_overrides[get_current_user] = _override
+    return {}  # empty dict; override handles auth, no Bearer token needed
+```
+
+- [ ] **Step 2: Run test — must fail**
+
+```bash
+docker compose exec -T api pytest tests/test_profile_extract_icp.py -v
+```
+
+Expected: FAIL — response model doesn't include `icp` / `seller_mirror`, extractor doesn't call the new prompt, DB row doesn't populate the new columns.
+
+- [ ] **Step 3: Extend profile_extractor service**
+
+Modify `backend/app/services/profile_extractor.py`. Append a new top-level coroutine `extract_icp_and_seller_mirror` (keep the existing `extract_capability_profile` unchanged):
+
+```python
+import json
+from app.prompts import extract_icp_and_seller_mirror as icp_prompt
+
+
+async def extract_icp_and_seller_mirror(
+    *,
+    source_text: str,
+    llm_override=None,
+) -> tuple[str, str]:
+    """Call the ICP+seller_mirror prompt. Returns (icp, seller_mirror) strings.
+
+    Parse JSON, minimal schema check. Raises ValueError on malformed output.
+    """
+    from app.services.llm import get_llm_client
+    llm = llm_override or get_llm_client()
+    user_msg = icp_prompt.build_user_message(source_text=source_text)
+
+    raw = await llm.complete(
+        prompt=user_msg,
+        system=icp_prompt.SYSTEM_PROMPT,
+        model="gpt-5.4-mini",  # matches OPENAI_MODEL_EXPENSIVE
+        max_tokens=1200,
+    )
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"[profile_extractor] ICP prompt returned non-JSON: {e}. Raw: {raw[:200]}"
+        )
+    if "icp" not in parsed or "seller_mirror" not in parsed:
+        raise ValueError(
+            f"[profile_extractor] ICP response missing required keys. Got: {list(parsed.keys())}"
+        )
+    return parsed["icp"], parsed["seller_mirror"]
+```
+
+- [ ] **Step 4: Extend `/profile/extract` router**
+
+The existing handler in `backend/app/routers/profile.py` uses the **ORM construct + flush + parameterized UPDATE for embedding** pattern. We follow the same pattern for the two new embeddings. Exact variable names from the file (verified by reading it): the extracted object is `profile`, the ORM instance is `version`, the version number is `version_number`, the capability embedding is `embedding`.
+
+**4a. Extend the response model:**
+
+Replace:
+
+```python
+class ProfileExtractResponse(BaseModel):
+    company_name: str
+    capability_summary: str
+    signal_keywords: list[str]
+    version: int
+```
+
+with:
+
+```python
+class ProfileExtractResponse(BaseModel):
+    company_name: str
+    capability_summary: str
+    signal_keywords: list[str]
+    version: int
+    icp: str
+    seller_mirror: str
+```
+
+**4b. Extract ICP + seller_mirror after the capability call, embed both.**
+
+In the handler, right after the existing `embedding = await emb.embed(profile.capability_summary)` line, insert:
+
+```python
+    from app.services.profile_extractor import extract_icp_and_seller_mirror
+
+    # Source text for ICP extraction: prefer the user-provided text; if only a
+    # URL was given, the capability summary itself is a faithful summary of
+    # what the crawler found and is a reasonable substitute.
+    icp_source_text = body.text or profile.capability_summary
+    icp_text, seller_mirror_text = await extract_icp_and_seller_mirror(
+        source_text=icp_source_text,
+        llm_override=llm,
+    )
+    icp_embedding = await emb.embed(icp_text)
+    seller_mirror_embedding = await emb.embed(seller_mirror_text)
+```
+
+**4c. Pass icp/seller_mirror text into the ORM constructor.**
+
+Replace:
+
+```python
+    version = CapabilityProfileVersion(
+        workspace_id=current_user.workspace_id,
+        version=version_number,
+        raw_text=profile.capability_summary,
+        source="url" if body.url else "document",
+        signal_keywords=profile.signal_keywords,
+        anti_keywords=profile.anti_keywords,
+        is_active=True,
+    )
+```
+
+with:
+
+```python
+    version = CapabilityProfileVersion(
+        workspace_id=current_user.workspace_id,
+        version=version_number,
+        raw_text=profile.capability_summary,
+        source="url" if body.url else "document",
+        signal_keywords=profile.signal_keywords,
+        anti_keywords=profile.anti_keywords,
+        icp=icp_text,
+        seller_mirror=seller_mirror_text,
+        is_active=True,
+    )
+```
+
+**4d. After the existing `await db.flush()` line, replace the single-embedding UPDATE with a three-embedding UPDATE.**
+
+Replace:
+
+```python
+    await db.execute(
+        text("UPDATE capability_profile_versions SET embedding = :emb WHERE id = :id"),
+        {"emb": str(embedding), "id": str(version.id)}
+    )
+```
+
+with:
+
+```python
+    await db.execute(
+        text(
+            "UPDATE capability_profile_versions "
+            "SET embedding = :emb, "
+            "    icp_embedding = :icp_emb, "
+            "    seller_mirror_embedding = :mirror_emb "
+            "WHERE id = :id"
+        ),
+        {
+            "emb": str(embedding),
+            "icp_emb": str(icp_embedding),
+            "mirror_emb": str(seller_mirror_embedding),
+            "id": str(version.id),
+        },
+    )
+```
+
+**4e. Extend the response construction:**
+
+Replace:
+
+```python
+    return ProfileExtractResponse(
+        company_name=profile.company_name,
+        capability_summary=profile.capability_summary,
+        signal_keywords=profile.signal_keywords,
+        version=version_number,
+    )
+```
+
+with:
+
+```python
+    return ProfileExtractResponse(
+        company_name=profile.company_name,
+        capability_summary=profile.capability_summary,
+        signal_keywords=profile.signal_keywords,
+        version=version_number,
+        icp=icp_text,
+        seller_mirror=seller_mirror_text,
+    )
+```
+
+- [ ] **Step 5: Run the integration test — must pass**
+
+```bash
+docker compose exec -T api pytest tests/test_profile_extract_icp.py -v
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 6: Full suite regression — must stay green**
+
+```bash
+docker compose exec -T api pytest -q
+```
+
+The existing `/profile/extract` tests must still pass — adding ICP fields should not break the capability-extraction path.
+
+- [ ] **Step 7: Dispatch `superpowers:code-reviewer`**
+
+Security-sensitive check: `source_text` flows into the ICP prompt's user message only (never the system prompt). `icp_text` / `seller_mirror_text` are treated as untrusted LLM output — parsed as JSON, schema-validated, never interpolated into shell or SQL. Confirm parameterized SQL used for the INSERT.
+
+- [ ] **Step 8: Commit + PR**
+
+```bash
+git checkout -b feat/phase-2-6-profile-extract-icp
+git add backend/app/services/profile_extractor.py \
+        backend/app/routers/profile.py \
+        backend/tests/test_profile_extract_icp.py \
+        backend/tests/conftest.py  # if fixtures added
+git commit -m "feat(profile): extract + persist ICP and seller_mirror
+
+POST /profile/extract now calls the ICP+seller_mirror prompt alongside
+capability extraction and persists both text fields + their embeddings
+on capability_profile_versions. Response model extended with icp and
+seller_mirror strings so the wizard (Task 7) can show them.
+
+Part of Phase 2.6 — see docs/phase-2-6/design.md §4.3 + §8 step 2."
+git push -u origin feat/phase-2-6-profile-extract-icp
+gh pr create --title "feat(profile): persist ICP + seller_mirror on extract" \
+             --body "..."
+```
+
+---
+
+## Task 5: Pipeline branch on `use_hybrid_scoring`
+
+Modify `app/workers/pipeline.py` so that workspaces with the flag flipped score via the hybrid path, while others continue on the existing `compute_combined_score`.
+
+**Files:**
+- Modify: `backend/app/workers/pipeline.py` — add hybrid branch
+- Test: `backend/tests/test_pipeline_hybrid_scoring.py`
+
+Branch: `feat/phase-2-6-pipeline-branch`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `backend/tests/test_pipeline_hybrid_scoring.py`:
+
+```python
+"""Pipeline branches on workspace.use_hybrid_scoring.
+
+Case A: flag=False → existing compute_combined_score path; post stored with
+relationship/timing/combined scores, no fit_score.
+
+Case B: flag=True → hybrid path; post's combined_score = fit_score * intent_score
+(where fit_score comes from connection.fit_score and intent_score from
+relevance + timing), connection.fit_score is populated if null.
+"""
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.connection import Connection
+from app.models.workspace import Workspace, CapabilityProfileVersion
+from app.models.post import Post
+
+
+@pytest.mark.asyncio
+async def test_pipeline_legacy_path_when_flag_false(db_session, pipeline_setup):
+    """flag=False: uses compute_combined_score (existing behavior)."""
+    workspace_id, post_id, connection_id = await pipeline_setup(use_hybrid=False)
+
+    from app.workers.pipeline import _run_pipeline
+    await _run_pipeline(post_id, workspace_id)
+
+    post = (await db_session.execute(
+        select(Post).where(Post.id == post_id)
+    )).scalar_one()
+    conn = (await db_session.execute(
+        select(Connection).where(Connection.id == connection_id)
+    )).scalar_one()
+
+    assert post.combined_score is not None
+    assert post.relationship_score is not None
+    # Legacy path does not populate fit_score on the connection
+    assert conn.fit_score is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_hybrid_path_when_flag_true(db_session, pipeline_setup):
+    """flag=True: uses compute_hybrid_score. Stores fit_score on the connection."""
+    workspace_id, post_id, connection_id = pipeline_setup(use_hybrid=True)
+
+    from app.workers.pipeline import _run_pipeline
+    await _run_pipeline(post_id, workspace_id)
+
+    post = (await db_session.execute(
+        select(Post).where(Post.id == post_id)
+    )).scalar_one()
+    conn = (await db_session.execute(
+        select(Connection).where(Connection.id == connection_id)
+    )).scalar_one()
+
+    # Hybrid path: combined_score = fit * intent
+    assert post.combined_score is not None
+    assert 0.0 <= post.combined_score <= 1.0
+    assert conn.fit_score is not None
+    assert 0.0 <= conn.fit_score <= 1.0
+```
+
+Add a `pipeline_setup` factory fixture to `backend/tests/conftest.py`:
+
+```python
+@pytest_asyncio.fixture
+async def pipeline_setup(db_session):
+    """Factory: returns an async callable that creates a workspace + user +
+    capability profile (with ICP/seller_mirror embeddings) + connection + post.
+    Returns (workspace_id, post_id, connection_id)."""
+    from datetime import datetime, timezone
+    from uuid import uuid4
+    from sqlalchemy import text as sql_text
+
+    async def _factory(*, use_hybrid: bool):
+        from app.models.workspace import Workspace, CapabilityProfileVersion
+        from app.models.user import User
+        from app.models.connection import Connection
+        from app.models.post import Post
+
+        ws = Workspace(
+            name="PipelineTestWS",
+            plan_tier="starter",
+            matching_threshold=0.1,  # low so scores pass through
+            use_hybrid_scoring=use_hybrid,
+        )
+        db_session.add(ws)
+        await db_session.flush()
+
+        user = User(email=f"u-{uuid4()}@test", password_hash="x", workspace_id=ws.id)
+        db_session.add(user)
+
+        profile = CapabilityProfileVersion(
+            workspace_id=ws.id,
+            version=1,
+            raw_text="Test capability: customer data platform for D2C brands.",
+            source="text",
+            signal_keywords=["cdp"],
+            anti_keywords=[],
+            icp="Marketing and growth leaders at D2C brands with >$1M ARR. Not competing martech vendors.",
+            seller_mirror="Founders, CEOs, CPOs at martech SaaS companies.",
+            is_active=True,
+        )
+        db_session.add(profile)
+        await db_session.flush()
+
+        # Populate the three pgvector columns via parameterized SQL.
+        fake_emb = "[" + ",".join(["0.1"] * 1536) + "]"
+        await db_session.execute(
+            sql_text(
+                "UPDATE capability_profile_versions "
+                "SET embedding = CAST(:e AS vector), "
+                "    icp_embedding = CAST(:e AS vector), "
+                "    seller_mirror_embedding = CAST(:e AS vector) "
+                "WHERE id = :id"
+            ),
+            {"e": fake_emb, "id": str(profile.id)},
+        )
+
+        conn = Connection(
+            workspace_id=ws.id,
+            user_id=user.id,
+            linkedin_id=f"li-{uuid4()}",
+            name="Test Buyer",
+            headline="Head of Growth at Acme D2C",
+            company="Acme D2C",
+            degree=2,
+        )
+        db_session.add(conn)
+        await db_session.flush()
+
+        post = Post(
+            workspace_id=ws.id,
+            connection_id=conn.id,
+            linkedin_post_id=f"p-{uuid4()}",
+            content="Looking at customer data tooling for our D2C stack.",
+            posted_at=datetime.now(timezone.utc),
+            ingested_at=datetime.now(timezone.utc),
+        )
+        db_session.add(post)
+        await db_session.flush()
+
+        # Populate post embedding.
+        await db_session.execute(
+            sql_text("UPDATE posts SET embedding = CAST(:e AS vector) WHERE id = :id"),
+            {"e": fake_emb, "id": str(post.id)},
+        )
+        await db_session.commit()
+
+        return ws.id, post.id, conn.id
+
+    return _factory
+```
+
+Note: Since `Post` and `Connection` have required fields like `linkedin_post_id` and `linkedin_id` with unique constraints, the UUID suffixes above prevent collisions across tests. If existing model columns have additional required fields, add them here — the Post / Connection / User constructors above mirror their current shapes (2026-04-20). Verify against `app/models/post.py` and `app/models/connection.py` at implementation time.
+
+- [ ] **Step 2: Run — must fail**
+
+```bash
+docker compose exec -T api pytest tests/test_pipeline_hybrid_scoring.py -v
+```
+
+Expected: FAIL — hybrid branch doesn't exist yet.
+
+- [ ] **Step 3: Modify pipeline.py**
+
+Verified shape: pipeline.py imports everything inside `_run_pipeline` (local imports). The embedding provider is `embedding_provider` (module-level lazy singleton, imported at line 61). The `profile` variable already holds the active `CapabilityProfileVersion` (loaded at line 84), so the hybrid path can read `profile.icp_embedding` and `profile.seller_mirror_embedding` directly without a second query. `ScoringResult` is a dataclass from `app.services.scorer` with a `priority: Priority` enum field.
+
+**3a. Extend the imports inside `_run_pipeline`**. Locate the block at lines 50–68 and add to it:
+
+```python
+    from app.services.scorer import compute_combined_score, ScoringResult, Priority
+    from app.services.fit_scorer import compute_fit_score, compute_intent_score, compute_hybrid_score
+```
+
+(The existing file already has `from app.services.scorer import compute_combined_score` — replace that line with the extended import above.)
+
+**3b. Replace the scoring block** at lines 202–208. Currently:
+
+```python
+        scoring = compute_combined_score(
+            relevance_score=relevance_score,
+            connection=connection,
+            posted_at=post.posted_at or post.ingested_at,
+            weights=workspace.scoring_weights,
+            keyword_match_strength=keyword_match_strength,
+        )
+```
+
+Replace with:
+
+```python
+        if workspace.use_hybrid_scoring and profile.icp_embedding is not None and profile.seller_mirror_embedding is not None:
+            # Hybrid path. Populate connection.fit_score on first encounter.
+            if connection.fit_score is None:
+                text_for_embed = f"{connection.headline or ''} {connection.company or ''}".strip()
+                if text_for_embed:
+                    conn_emb = await embedding_provider.embed(text_for_embed)
+                    # profile.icp_embedding and .seller_mirror_embedding come back as
+                    # pgvector objects; cast via list() so the fit_scorer sees Sequence[float].
+                    connection.fit_score = compute_fit_score(
+                        icp_embedding=list(profile.icp_embedding),
+                        seller_mirror_embedding=list(profile.seller_mirror_embedding),
+                        connection_embedding=conn_emb,
+                        lambda_=0.3,  # hardcoded; replace with workspace.hybrid_lambda after Task 9 calibration
+                    )
+                else:
+                    connection.fit_score = 0.0
+                await db.flush()
+
+            intent = compute_intent_score(
+                relevance_score=relevance_score,
+                posted_at=post.posted_at or post.ingested_at,
+            )
+            final = compute_hybrid_score(
+                fit_score=connection.fit_score,
+                intent_score=intent,
+            )
+
+            # Derive priority from the hybrid final score using the same
+            # thresholds as legacy scoring (0.80 high, 0.55 medium).
+            if final >= 0.80:
+                priority = Priority.HIGH
+            elif final >= 0.55:
+                priority = Priority.MEDIUM
+            else:
+                priority = Priority.LOW
+
+            # Timing is already folded into `intent`; surface the raw component
+            # for the legacy DB columns so dashboards/debugging still work.
+            posted = post.posted_at or post.ingested_at
+            if posted.tzinfo is None:
+                posted = posted.replace(tzinfo=timezone.utc)
+            hours_old = max(0.0, (datetime.now(timezone.utc) - posted).total_seconds() / 3600.0)
+            timing_component = max(0.0, 1.0 - hours_old / 24.0)
+
+            scoring = ScoringResult(
+                relevance_score=relevance_score,
+                relationship_score=0.0,  # not used in hybrid; degree filter lives on dashboard
+                timing_score=timing_component,
+                combined_score=final,
+                priority=priority,
+            )
+        else:
+            if workspace.use_hybrid_scoring:
+                logger.warning(
+                    "[pipeline] use_hybrid_scoring=True but ICP/seller_mirror embeddings missing "
+                    "for workspace_id=%s profile_id=%s — falling back to legacy scorer. "
+                    "Run /profile/extract then scripts/backfill_fit_scores.py to populate.",
+                    workspace_id, profile.id,
+                )
+            scoring = compute_combined_score(
+                relevance_score=relevance_score,
+                connection=connection,
+                posted_at=post.posted_at or post.ingested_at,
+                weights=workspace.scoring_weights,
+                keyword_match_strength=keyword_match_strength,
+            )
+```
+
+**Notes:**
+- `datetime` and `timezone` are already imported inside `_run_pipeline` (line 52).
+- `Priority.HIGH/MEDIUM/LOW` — verify the exact enum casing by opening `app/services/scorer.py`. If the enum uses lowercase (`Priority.high`), use that instead. The existing pipeline uses `scoring.priority.value` at line 294, so it is an enum — only the case of the members needs verification at implementation time.
+- **Lambda is hardcoded at 0.3** for this task. If Task 9 calibration finds a non-0.3 optimum, open a follow-up task to add `workspaces.hybrid_lambda REAL DEFAULT 0.3` via migration 011 and read it here.
+- No new top-of-file imports needed; everything is inside `_run_pipeline`.
+
+- [ ] **Step 4: Run integration test — must pass**
+
+```bash
+docker compose exec -T api pytest tests/test_pipeline_hybrid_scoring.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Full suite — must stay green**
+
+```bash
+docker compose exec -T api pytest -q
+```
+
+- [ ] **Step 6: Dispatch `superpowers:code-reviewer`**
+
+Spec compliance: branch per design §3.7. Code quality: fallback on missing ICP embeddings (warn, use legacy — not hard-fail). Lambda is hardcoded with a TODO pointer to Task 9.
+
+- [ ] **Step 7: Commit + PR**
+
+```bash
+git checkout -b feat/phase-2-6-pipeline-branch
+git add backend/app/workers/pipeline.py backend/tests/test_pipeline_hybrid_scoring.py
+git commit -m "feat(pipeline): branch scoring path on workspace.use_hybrid_scoring
+
+When the flag is True, pipeline scores via compute_hybrid_score (fit × intent)
+instead of compute_combined_score. Fit is computed on first encounter of each
+connection and cached on connection.fit_score.
+
+Lambda hardcoded at 0.3; replace with workspace.hybrid_lambda column after
+calibration (Task 9) picks the per-workspace optimum.
+
+Fallback: if use_hybrid_scoring=True but the workspace lacks ICP/seller_mirror
+embeddings (e.g., flag flipped before Task 4 ran against it), log a warning
+and fall through to the legacy scorer rather than hard-failing."
+git push -u origin feat/phase-2-6-pipeline-branch
+gh pr create --title "feat(pipeline): hybrid scoring branch on use_hybrid_scoring flag" --body "..."
+```
+
+---
+
+## Task 6: `backfill_fit_scores.py` one-shot script
+
+Populate `connection.fit_score` for every connection in a workspace, so that when the flag flips, the pipeline doesn't pay the per-connection embedding cost on first encounter.
+
+**Files:**
+- Create: `backend/scripts/backfill_fit_scores.py`
+- Test: `backend/tests/test_backfill_fit_scores.py`
+
+Branch: `feat/phase-2-6-backfill-fit`
+
+- [ ] **Step 1a: Add the fixtures to conftest.py**
+
+```python
+@pytest_asyncio.fixture
+async def workspace_with_icp(db_session):
+    """Workspace + active CapabilityProfileVersion with icp/seller_mirror embeddings populated.
+    Returns the workspace_id (UUID)."""
+    from uuid import uuid4
+    from sqlalchemy import text as sql_text
+    from app.models.workspace import Workspace, CapabilityProfileVersion
+    from app.models.user import User
+
+    ws = Workspace(name="BackfillTest", plan_tier="starter", use_hybrid_scoring=True)
+    db_session.add(ws)
+    await db_session.flush()
+
+    user = User(email=f"u-{uuid4()}@test", password_hash="x", workspace_id=ws.id)
+    db_session.add(user)
+
+    profile = CapabilityProfileVersion(
+        workspace_id=ws.id, version=1,
+        raw_text="...", source="text",
+        signal_keywords=[], anti_keywords=[],
+        icp="ICP text.", seller_mirror="Seller mirror text.",
+        is_active=True,
+    )
+    db_session.add(profile)
+    await db_session.flush()
+
+    fake_emb = "[" + ",".join(["0.1"] * 1536) + "]"
+    await db_session.execute(
+        sql_text(
+            "UPDATE capability_profile_versions "
+            "SET embedding = CAST(:e AS vector), "
+            "    icp_embedding = CAST(:e AS vector), "
+            "    seller_mirror_embedding = CAST(:e AS vector) "
+            "WHERE id = :id"
+        ),
+        {"e": fake_emb, "id": str(profile.id)},
+    )
+    # Stash user_id on the workspace object for the connection fixtures below.
+    ws._test_user_id = user.id
+    await db_session.commit()
+    return ws.id
+
+
+async def _add_connection(db, workspace_id, user_id, *, headline: str, company: str, fit_score=None):
+    from uuid import uuid4
+    from app.models.connection import Connection
+    conn = Connection(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        linkedin_id=f"li-{uuid4()}",
+        name="N",
+        headline=headline,
+        company=company,
+        degree=2,
+        fit_score=fit_score,
+    )
+    db.add(conn)
+    await db.flush()
+    return conn.id
+
+
+@pytest_asyncio.fixture
+async def seeded_connections(db_session, workspace_with_icp):
+    """3 connections in the workspace, all with fit_score=None."""
+    from sqlalchemy import select
+    from app.models.workspace import Workspace
+    ws = (await db_session.execute(
+        select(Workspace).where(Workspace.id == workspace_with_icp)
+    )).scalar_one()
+    ids = []
+    for h, c in [
+        ("Head of Growth at Acme D2C", "Acme D2C"),
+        ("CMO", "Retail Co"),
+        ("VP Marketing", "BrandX"),
+    ]:
+        ids.append(await _add_connection(db_session, ws.id, ws._test_user_id, headline=h, company=c))
+    await db_session.commit()
+    return ids
+
+
+@pytest_asyncio.fixture
+async def seeded_connections_mixed(db_session, workspace_with_icp):
+    """Mixed: 2 connections without fit_score + 1 with fit_score=0.5 pre-populated."""
+    from sqlalchemy import select
+    from app.models.workspace import Workspace
+    ws = (await db_session.execute(
+        select(Workspace).where(Workspace.id == workspace_with_icp)
+    )).scalar_one()
+    ids = [
+        await _add_connection(db_session, ws.id, ws._test_user_id, headline="CMO", company="X", fit_score=None),
+        await _add_connection(db_session, ws.id, ws._test_user_id, headline="VP Growth", company="Y", fit_score=None),
+        await _add_connection(db_session, ws.id, ws._test_user_id, headline="Founder", company="Z", fit_score=0.5),
+    ]
+    await db_session.commit()
+    return ids
+```
+
+- [ ] **Step 1b: Write the failing test**
+
+Create `backend/tests/test_backfill_fit_scores.py`:
+
+```python
+"""Integration test: backfill script populates fit_score for every connection."""
+import pytest
+from sqlalchemy import select
+
+from app.models.connection import Connection
+
+
+@pytest.mark.asyncio
+async def test_backfill_populates_fit_score_for_all_connections(
+    db_session, workspace_with_icp, seeded_connections,
+):
+    from scripts.backfill_fit_scores import run
+
+    # Override the embedding provider to avoid real OpenAI calls.
+    from app.services import embedding as emb_mod
+    class _FakeProvider:
+        async def embed(self, text: str) -> list[float]:
+            return [0.2] * 1536
+    emb_mod._provider = _FakeProvider()
+
+    summary = await run(db_session, workspace_id=workspace_with_icp)
+
+    assert summary["updated"] == 3
+    conns = (await db_session.execute(
+        select(Connection).where(Connection.workspace_id == workspace_with_icp)
+    )).scalars().all()
+    for c in conns:
+        assert c.fit_score is not None
+        assert 0.0 <= c.fit_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_connections_with_existing_fit_score(
+    db_session, workspace_with_icp, seeded_connections_mixed,
+):
+    """Default mode skips connections that already have a fit_score."""
+    from scripts.backfill_fit_scores import run
+    from app.services import embedding as emb_mod
+    class _FakeProvider:
+        async def embed(self, text: str) -> list[float]:
+            return [0.2] * 1536
+    emb_mod._provider = _FakeProvider()
+
+    summary = await run(db_session, workspace_id=workspace_with_icp, recompute_all=False)
+    assert summary["updated"] == 2  # the two with fit_score=None
+```
+
+Note: the `_reset_provider_singletons` autouse fixture in conftest clears `emb_mod._provider` at teardown, so the fake set here doesn't leak between tests.
+
+- [ ] **Step 2: Run — must fail**
+
+```bash
+docker compose exec -T api pytest tests/test_backfill_fit_scores.py -v
+```
+
+Expected: FAIL — script doesn't exist.
+
+- [ ] **Step 3: Write the backfill script**
+
+Create `backend/scripts/backfill_fit_scores.py`:
+
+```python
+"""One-shot script: populate connection.fit_score for a workspace.
+
+Loads the active CapabilityProfileVersion for the workspace (must have
+icp_embedding + seller_mirror_embedding). For each connection in the workspace:
+  1. Embed headline + company.
+  2. Compute fit_score via fit_scorer.
+  3. Persist.
+
+Usage inside api container:
+  python scripts/backfill_fit_scores.py --workspace-id <uuid>
+  python scripts/backfill_fit_scores.py --workspace-id <uuid> --recompute-all
+
+The --recompute-all flag forces re-embed of every connection, overwriting any
+existing fit_score. Useful after an ICP change.
+"""
+import argparse
+import asyncio
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.config import get_settings
+from app.models.connection import Connection
+from app.models.workspace import CapabilityProfileVersion
+from app.services.embedding import get_embedding_provider
+from app.services.fit_scorer import compute_fit_score
+
+
+async def run(db, workspace_id: UUID, *, recompute_all: bool = False, lambda_: float = 0.3) -> dict:
+    profile = (await db.execute(
+        select(CapabilityProfileVersion)
+        .where(CapabilityProfileVersion.workspace_id == workspace_id)
+        .where(CapabilityProfileVersion.is_active.is_(True))
+    )).scalar_one_or_none()
+    if profile is None:
+        raise RuntimeError(f"No active capability_profile_version for workspace {workspace_id}")
+    if profile.icp_embedding is None or profile.seller_mirror_embedding is None:
+        raise RuntimeError(
+            f"Workspace {workspace_id} active profile has no ICP/seller_mirror embeddings. "
+            "Run /profile/extract first."
+        )
+
+    emb = get_embedding_provider()
+
+    q = select(Connection).where(Connection.workspace_id == workspace_id)
+    if not recompute_all:
+        q = q.where(Connection.fit_score.is_(None))
+    connections = (await db.execute(q)).scalars().all()
+
+    icp_emb = list(profile.icp_embedding)
+    mirror_emb = list(profile.seller_mirror_embedding)
+
+    updated = 0
+    skipped_empty = 0
+    for conn in connections:
+        text = f"{conn.headline or ''} {conn.company or ''}".strip()
+        if not text:
+            conn.fit_score = 0.0
+            skipped_empty += 1
+            continue
+        conn_emb = await emb.embed(text)
+        conn.fit_score = compute_fit_score(
+            icp_embedding=icp_emb,
+            seller_mirror_embedding=mirror_emb,
+            connection_embedding=conn_emb,
+            lambda_=lambda_,
+        )
+        updated += 1
+
+    await db.commit()
+    return {"updated": updated, "skipped_empty": skipped_empty, "total": len(connections)}
+
+
+async def _main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace-id", type=UUID, required=True)
+    parser.add_argument("--recompute-all", action="store_true")
+    parser.add_argument("--lambda", type=float, default=0.3, dest="lambda_",
+                        help="Subtractive weight on seller_mirror term (default 0.3)")
+    args = parser.parse_args()
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with Session() as db:
+        summary = await run(
+            db,
+            workspace_id=args.workspace_id,
+            recompute_all=args.recompute_all,
+            lambda_=args.lambda_,
+        )
+        print(f"[backfill_fit_scores] {summary}")
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())
+```
+
+- [ ] **Step 4: Run tests — must pass**
+
+```bash
+docker compose exec -T api pytest tests/test_backfill_fit_scores.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Full suite — green**
+
+```bash
+docker compose exec -T api pytest -q
+```
+
+- [ ] **Step 6: Smoke test the CLI entry point**
+
+```bash
+docker compose exec -T api python scripts/backfill_fit_scores.py --help
+```
+
+Expected: argparse help output with --workspace-id, --recompute-all, --lambda.
+
+- [ ] **Step 7: Review + commit + PR**
+
+```bash
+git checkout -b feat/phase-2-6-backfill-fit
+git add backend/scripts/backfill_fit_scores.py backend/tests/test_backfill_fit_scores.py
+git commit -m "feat(scripts): one-shot backfill_fit_scores.py for Phase 2.6
+
+Populates connection.fit_score for every connection in a workspace by
+embedding headline+company and applying the fit_score formula against
+the workspace's active ICP + seller_mirror embeddings.
+
+Idempotent (skips non-null fit_scores by default). Use --recompute-all
+after an ICP change to invalidate the cache."
+git push -u origin feat/phase-2-6-backfill-fit
+gh pr create --title "feat(scripts): backfill_fit_scores.py" --body "..."
+```
+
+---
+
+## Task 7: Wizard frontend — ICP review step
+
+Insert a new review step into `SignalConfig.tsx` so the user sees the extracted ICP + seller_mirror before signals are generated. Lets them edit either paragraph inline.
+
+**Per Sonar's CLAUDE.md:** no automated integration tests on the frontend. Verify via `docker compose up -d frontend` + manual browser walkthrough. Human signoff before merging.
+
+**Files:**
+- Modify: `frontend/src/pages/SignalConfig.tsx` — add new Step 3 (ICP review), shift 3→4, 4→5, 5→6
+
+Branch: `feat/phase-2-6-wizard-icp-review`
+
+- [ ] **Step 1: Read the current SignalConfig.tsx structure**
+
+```bash
+cat frontend/src/pages/SignalConfig.tsx | head -50
+```
+
+Confirm current `Step = 1 | 2 | 3 | 4 | 5` layout.
+
+- [ ] **Step 2: Extend the Step union type and state**
+
+Change:
+
+```typescript
+type Step = 1 | 2 | 3 | 4 | 5;
+```
+
+to:
+
+```typescript
+type Step = 1 | 2 | 3 | 4 | 5 | 6;
+```
+
+Add ICP state:
+
+```typescript
+const [icp, setIcp] = useState<string>("");
+const [sellerMirror, setSellerMirror] = useState<string>("");
+const [icpEdited, setIcpEdited] = useState<boolean>(false);
+```
+
+- [ ] **Step 3: Split step 2's "Generating signals..." into two**
+
+Currently step 3 is "Generating signals...". We repurpose: step 3 becomes "Reviewing your ICP", and the signal-proposal step moves to 4.
+
+After the user submits `whatYouSell` + optional `icp`, call `/profile/extract` FIRST to get the ICP + seller_mirror text. Populate state. Render step 3 as a review screen:
+
+```tsx
+{step === 3 && (
+  <section>
+    <h2>Review who we think your buyers are</h2>
+    <p className="text-sm text-gray-600">
+      Before we generate signals, confirm the buyer persona and seller
+      persona we'll be comparing connections against. Edit anything that
+      looks off.
+    </p>
+
+    <label className="block mt-4">
+      <span className="font-medium">Your ideal buyer (ICP)</span>
+      <textarea
+        className="w-full mt-1 p-2 border rounded"
+        rows={6}
+        value={icp}
+        onChange={(e) => { setIcp(e.target.value); setIcpEdited(true); }}
+      />
+    </label>
+
+    <label className="block mt-4">
+      <span className="font-medium">Seller-mirror (subtracted during scoring)</span>
+      <p className="text-xs text-gray-500 mb-1">
+        What OTHER sellers of your capability look like on LinkedIn.
+        We subtract this signal so competing vendors don't rank as buyers.
+      </p>
+      <textarea
+        className="w-full mt-1 p-2 border rounded"
+        rows={6}
+        value={sellerMirror}
+        onChange={(e) => setSellerMirror(e.target.value)}
+      />
+    </label>
+
+    <div className="mt-6 flex gap-2">
+      <button onClick={() => setStep(2)}>← Back</button>
+      <button
+        className="btn-primary"
+        onClick={async () => {
+          if (icpEdited) {
+            // Persist edits back to the server
+            await apiClient.post("/profile/update-icp", { icp, seller_mirror: sellerMirror });
+          }
+          setStep(4);  // move to signal generation
+        }}
+      >
+        Looks right — generate signals
+      </button>
+    </div>
+  </section>
+)}
+```
+
+Shift the existing step 3, 4, 5 blocks to `step === 4`, `step === 5`, `step === 6`.
+
+- [ ] **Step 4: Modify the "call /profile/extract" handler**
+
+Where the wizard currently POSTs to `/profile/extract` (likely in step 2's submit handler), update the response handling to set the new state:
+
+```typescript
+const resp = await apiClient.post("/profile/extract", { text: whatYouSell });
+setIcp(resp.data.icp);
+setSellerMirror(resp.data.seller_mirror);
+setStep(3);  // go to ICP review BEFORE signal generation
+```
+
+- [ ] **Step 5: Add a backend endpoint for the edit path (optional but recommended)**
+
+If `/profile/update-icp` doesn't exist, either:
+- (a) skip the persist-on-edit behavior for now and track as a follow-up issue
+- (b) add a small endpoint in `app/routers/profile.py`:
+
+```python
+@router.post("/update-icp")
+async def update_icp(
+    body: dict,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    emb: EmbeddingProvider = Depends(get_embedding_provider),
+):
+    """Update the active capability_profile_version's ICP and/or seller_mirror.
+    Re-embed whichever fields are provided."""
+    icp = body.get("icp")
+    seller_mirror = body.get("seller_mirror")
+    if not icp and not seller_mirror:
+        raise HTTPException(400, "must provide icp and/or seller_mirror")
+
+    update_fields = {}
+    if icp:
+        update_fields["icp"] = icp
+        update_fields["icp_embedding"] = await emb.embed(icp)
+    if seller_mirror:
+        update_fields["seller_mirror"] = seller_mirror
+        update_fields["seller_mirror_embedding"] = await emb.embed(seller_mirror)
+
+    await db.execute(
+        update(CapabilityProfileVersion)
+        .where(CapabilityProfileVersion.workspace_id == current_user.workspace_id)
+        .where(CapabilityProfileVersion.is_active.is_(True))
+        .values(**update_fields)
+    )
+    await db.commit()
+    return {"ok": True}
+```
+
+Add a test for it. If skipping, open a GitHub issue: "Wire wizard ICP edits back to /profile/update-icp."
+
+**Recommendation:** include the endpoint in this task (it's ~20 lines + a test).
+
+- [ ] **Step 6: Manual browser walkthrough (required — no automated tests)**
+
+```bash
+docker compose up -d --build frontend
+open http://localhost:5173/signals/setup
+```
+
+Walk through:
+1. Enter "What do you sell?" text → submit
+2. Verify ICP + seller_mirror text appears, editable
+3. Edit each; click "Looks right — generate signals"
+4. Confirm signal generation completes
+5. Click through to step 5 (accept/reject signals) and step 6 (ready to save)
+6. Check browser devtools network tab: `/profile/extract` returned icp/seller_mirror fields; `/profile/update-icp` fired on edit.
+
+Take a screenshot of the new step 3 for the PR body.
+
+- [ ] **Step 7: Commit + PR**
+
+```bash
+git checkout -b feat/phase-2-6-wizard-icp-review
+git add frontend/src/pages/SignalConfig.tsx \
+        backend/app/routers/profile.py \
+        backend/tests/test_profile_update_icp.py
+git commit -m "feat(wizard): add ICP review step before signal generation
+
+New step 3 in the wizard shows the extracted ICP + seller_mirror text
+to the user. They can edit either paragraph; edits re-embed via a new
+POST /profile/update-icp endpoint.
+
+Per Phase 2.6 design §3.1 tier-2/3 ICP customization + §7 risk-2 mitigation."
+git push -u origin feat/phase-2-6-wizard-icp-review
+gh pr create --title "feat(wizard): ICP review step + /profile/update-icp endpoint" --body "..."
+```
+
+---
+
+## Task 8: Calibration — `analyze-hybrid` subcommand with λ sweep
+
+Extend `backend/scripts/calibrate_matching.py` with a new subcommand that:
+- Reads the existing labeled dataset (same 30-post dogfood set from PR #114)
+- For each λ in a sweep: computes per-connection fit_score, per-post intent_score, `final_score = fit * intent`
+- Reports P@5, Recall, top-5 competitor count at each λ
+- Picks the winning λ per the DoD (§3.8): P@5 ≥ 0.6, Recall ≥ 0.5, zero competitor posts in top-5
+
+**Files:**
+- Modify: `backend/scripts/calibrate_matching.py` — add `analyze-hybrid` subcommand + helpers
+- Test: `backend/tests/test_calibrate_hybrid.py`
+
+Branch: `feat/phase-2-6-calibrate-hybrid`
+
+The existing `calibrate_matching.py` already exposes `parse_labels(labels_path: Path) -> dict[str, bool]` at module scope (no refactor needed). The existing labeling format tracks only `is_match` per post — it does NOT have an `is_competitor` flag. Two ways to surface competitor leakage:
+- **(a)** Accept a `--competitors` flag pointing at a file of known competitor LinkedIn IDs or connection UUIDs; auto-count.
+- **(b)** Print top-5 posts with author headline/company so the user eyeballs competitor leakage.
+
+This task implements **both**: auto-count if `--competitors` is provided, always print top-5 for visual verification.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `backend/tests/test_calibrate_hybrid.py`:
+
+```python
+"""Unit tests for the metrics helpers used by analyze-hybrid."""
+import pytest
+
+from scripts.calibrate_matching import (
+    precision_at_k,
+    recall_at_k,
+    competitor_count_in_top_k,
+)
+
+
+def test_precision_at_5_mixed_ranking():
+    # 3 of top-5 are true matches → 0.6
+    # Each item is (score, is_match, is_competitor).
+    ranked = [
+        (0.9, True, False), (0.8, False, False), (0.7, True, False),
+        (0.6, True, False), (0.5, False, False), (0.4, True, False),
+    ]
+    assert precision_at_k(ranked, k=5) == 0.6
+
+
+def test_precision_at_5_fewer_than_k():
+    ranked = [(0.9, True, False), (0.8, True, False)]
+    assert precision_at_k(ranked, k=5) == 1.0  # 2/2
+
+
+def test_recall_half_caught():
+    ranked = [
+        (0.9, True, False), (0.8, False, False), (0.7, True, False),
+        (0.6, False, False), (0.5, True, False), (0.4, True, False),
+    ]
+    # top-5 has 3 true matches; total true matches = 4 → 3/4 = 0.75
+    assert recall_at_k(ranked, k=5) == 0.75
+
+
+def test_competitor_count_in_top_5():
+    ranked = [
+        (0.9, True, False),   (0.85, False, True),   (0.8, False, True),
+        (0.7, True, False),   (0.6, False, False),
+    ]
+    assert competitor_count_in_top_k(ranked, k=5) == 2
+
+
+def test_competitor_count_zero_when_none_flagged():
+    ranked = [(0.9, True, False)] * 5
+    assert competitor_count_in_top_k(ranked, k=5) == 0
+```
+
+- [ ] **Step 2: Run — must fail**
+
+```bash
+docker compose exec -T api pytest tests/test_calibrate_hybrid.py -v
+```
+
+Expected: FAIL — helpers don't exist.
+
+- [ ] **Step 3: Extend calibrate_matching.py**
+
+In `backend/scripts/calibrate_matching.py`, add these top-level helpers below `compute_metrics_at_threshold`:
+
+```python
+def precision_at_k(ranked: list[tuple[float, bool, bool]], k: int = 5) -> float:
+    """ranked: list of (score, is_match, is_competitor) sorted by score desc.
+    Returns matches_in_top_k / len(top_k)."""
+    top = ranked[:k]
+    if not top:
+        return 0.0
+    matches = sum(1 for _score, is_match, _comp in top if is_match)
+    return matches / len(top)
+
+
+def recall_at_k(ranked: list[tuple[float, bool, bool]], k: int = 5) -> float:
+    """Recall at k against all true matches in the dataset (not just top-k)."""
+    total_true = sum(1 for _score, is_match, _comp in ranked if is_match)
+    if total_true == 0:
+        return 0.0
+    top_true = sum(1 for _score, is_match, _comp in ranked[:k] if is_match)
+    return top_true / total_true
+
+
+def competitor_count_in_top_k(ranked: list[tuple[float, bool, bool]], k: int = 5) -> int:
+    """Count competitor-flagged posts in top-k."""
+    return sum(1 for _score, _is_match, is_comp in ranked[:k] if is_comp)
+
+
+def load_competitor_set(competitors_path: Path | None) -> set[str]:
+    """Load a set of connection UUID strings from a newline-separated file.
+    Returns empty set if path is None. Ignores blank lines and # comments."""
+    if competitors_path is None:
+        return set()
+    out: set[str] = set()
+    for line in competitors_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.add(line.lower())
+    return out
+```
+
+Add the subcommand registration in `main()` after the existing `analyze` parser:
+
+```python
+    hy = subparsers.add_parser("analyze-hybrid", help="Sweep λ for Phase 2.6 hybrid scoring")
+    hy.add_argument("--workspace-id", type=UUID, required=True)
+    hy.add_argument("--labels", type=Path, required=True,
+                    help="Labeled dataset file (same format as the existing analyze input)")
+    hy.add_argument("--lambdas", type=str, default="0.0,0.1,0.2,0.3,0.5,0.7,1.0",
+                    help="Comma-separated λ values to sweep")
+    hy.add_argument("--competitors", type=Path, default=None,
+                    help="Optional: file with newline-separated connection UUIDs known to be competitors. "
+                         "If provided, analyzer reports top-5 competitor leakage automatically.")
+```
+
+Dispatch it inside `main()`:
+
+```python
+    elif args.cmd == "analyze-hybrid":
+        asyncio.run(cmd_analyze_hybrid(args))
+```
+
+Add the command handler at module scope:
+
+```python
+async def cmd_analyze_hybrid(args) -> None:
+    from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+    from sqlalchemy import select
+    from app.config import get_settings
+    from app.models.workspace import CapabilityProfileVersion
+    from app.models.connection import Connection
+    from app.models.post import Post
+    from app.services.fit_scorer import (
+        compute_fit_score,
+        compute_intent_score,
+        compute_hybrid_score,
+        cosine_similarity,
+    )
+    from app.services.embedding import embedding_provider
+
+    labels_map = parse_labels(args.labels)   # {post_id: is_match}
+    if not labels_map:
+        print(f"[calibrate-hybrid] no labels parsed from {args.labels}")
+        sys.exit(1)
+
+    lambdas = [float(x) for x in args.lambdas.split(",")]
+    competitor_ids = load_competitor_set(args.competitors)
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with Session() as db:
+        profile = (await db.execute(
+            select(CapabilityProfileVersion)
+            .where(CapabilityProfileVersion.workspace_id == args.workspace_id)
+            .where(CapabilityProfileVersion.is_active.is_(True))
+        )).scalar_one_or_none()
+        if profile is None:
+            print(f"[calibrate-hybrid] no active capability_profile_version for {args.workspace_id}")
+            sys.exit(1)
+        if profile.icp_embedding is None or profile.seller_mirror_embedding is None:
+            print("[calibrate-hybrid] active profile has no ICP/seller_mirror embeddings. "
+                  "Run /profile/extract first.")
+            sys.exit(1)
+
+        icp_emb = list(profile.icp_embedding)
+        mirror_emb = list(profile.seller_mirror_embedding)
+        cap_emb = list(profile.embedding) if profile.embedding is not None else None
+
+        # Fetch each labeled post joined with its connection + embedding text.
+        post_rows = (await db.execute(
+            select(Post, Connection)
+            .join(Connection, Post.connection_id == Connection.id)
+            .where(Post.id.in_([UUID(pid) for pid in labels_map.keys()]))
+        )).all()
+
+        # Fetch post embeddings via raw SQL (pgvector cast to text, then json-parse).
+        import json
+        from sqlalchemy import text as sql_text
+        post_emb_rows = (await db.execute(
+            sql_text("SELECT id::text, embedding::text FROM posts WHERE id = ANY(:ids)"),
+            {"ids": list(labels_map.keys())},
+        )).all()
+        post_embs = {
+            pid: json.loads(emb_str) if emb_str else None
+            for pid, emb_str in post_emb_rows
+        }
+
+        # Embed each connection's headline+company exactly once.
+        conn_embs: dict[str, list[float]] = {}
+        for _post, conn in post_rows:
+            cid = str(conn.id)
+            if cid in conn_embs:
+                continue
+            text_for_embed = f"{conn.headline or ''} {conn.company or ''}".strip()
+            conn_embs[cid] = await embedding_provider.embed(text_for_embed) if text_for_embed else [0.0] * 1536
+
+        print(f"\n{'λ':>5} | {'P@5':>5} | {'R@5':>5} | {'comp@5':>6} | DoD?")
+        print("-" * 45)
+
+        best_lambda = None
+        for lam in lambdas:
+            ranked: list[tuple[float, bool, bool]] = []
+            top5_preview: list[tuple[float, str, str, str]] = []  # (score, post_id, headline, company)
+
+            for post, conn in post_rows:
+                pid = str(post.id)
+                if pid not in labels_map:
+                    continue
+                post_emb = post_embs.get(pid)
+                if post_emb is None or cap_emb is None:
+                    continue
+                fit = compute_fit_score(
+                    icp_embedding=icp_emb,
+                    seller_mirror_embedding=mirror_emb,
+                    connection_embedding=conn_embs[str(conn.id)],
+                    lambda_=lam,
+                )
+                relevance = cosine_similarity(cap_emb, post_emb)
+                intent = compute_intent_score(
+                    relevance_score=relevance,
+                    posted_at=post.posted_at or post.ingested_at,
+                )
+                final = compute_hybrid_score(fit, intent)
+
+                is_match = labels_map[pid]
+                is_competitor = str(conn.id).lower() in competitor_ids
+                ranked.append((final, is_match, is_competitor))
+                top5_preview.append((final, pid, conn.headline or "", conn.company or ""))
+
+            ranked.sort(key=lambda x: -x[0])
+            top5_preview.sort(key=lambda x: -x[0])
+
+            p5 = precision_at_k(ranked, k=5)
+            r5 = recall_at_k(ranked, k=5)
+            comp5 = competitor_count_in_top_k(ranked, k=5)
+            dod = "YES" if (p5 >= 0.6 and r5 >= 0.5 and comp5 == 0) else "no"
+            print(f"{lam:>5.2f} | {p5:>5.2f} | {r5:>5.2f} | {comp5:>6d} | {dod}")
+
+            if dod == "YES" and best_lambda is None:
+                best_lambda = lam
+                # Show top-5 for visual competitor check at the winning λ
+                print(f"\n  top-5 at λ={lam}:")
+                for score, pid, headline, company in top5_preview[:5]:
+                    print(f"    {score:.3f}  {pid}  {headline[:60]}  @ {company[:40]}")
+
+        if best_lambda is None:
+            print("\n[calibrate-hybrid] no λ satisfied DoD (P@5 ≥ 0.6, R@5 ≥ 0.5, zero top-5 competitors).")
+            print("See design.md §5 step 8 for diagnostic paths.")
+
+    await engine.dispose()
+```
+
+- [ ] **Step 4: Tests pass**
+
+```bash
+docker compose exec -T api pytest tests/test_calibrate_hybrid.py -v
+docker compose exec -T api pytest -q
+```
+
+- [ ] **Step 5: Smoke test the CLI**
+
+```bash
+docker compose exec -T api python scripts/calibrate_matching.py analyze-hybrid --help
+```
+
+- [ ] **Step 6: Review + commit + PR**
+
+```bash
+git checkout -b feat/phase-2-6-calibrate-hybrid
+git add backend/scripts/calibrate_matching.py backend/tests/test_calibrate_hybrid.py
+git commit -m "feat(eval): analyze-hybrid subcommand with λ sweep
+
+Extends calibrate_matching.py with an analyze-hybrid subcommand that
+evaluates the Phase 2.6 hybrid scoring model across a λ sweep. For each
+λ, computes P@5, Recall, and top-5 competitor count against the labeled
+dogfood dataset. Surfaces the DoD (P@5≥0.6, Recall≥0.5, zero competitors
+in top-5 per design §3.8).
+
+Also factors out parse_labels_file() so the existing analyze command and
+the new analyze-hybrid command share the same parser."
+git push -u origin feat/phase-2-6-calibrate-hybrid
+gh pr create --title "feat(eval): hybrid λ sweep in calibrate_matching.py" --body "..."
+```
+
+---
+
+## Task 9: Operational — calibration run, flip flag, retire legacy scorer
+
+**Not a code task.** No TDD steps. This is the go/no-go step that either ships Phase 2.6 or surfaces a design gap.
+
+### Sequence
+
+- [ ] **Step 1: Extract ICP + seller_mirror for Dwao workspace via POST /profile/extract**
+
+```bash
+# Run through the wizard at /signals/setup, or POST directly:
+curl -X POST http://localhost:8000/profile/extract \
+  -H "Authorization: Bearer $DWAO_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://dwao.in"}'
+```
+
+Verify the returned ICP + seller_mirror look reasonable. Iterate via `/profile/update-icp` if they don't.
+
+- [ ] **Step 2: Backfill fit_scores for Dwao**
+
+```bash
+docker compose exec -T api python scripts/backfill_fit_scores.py \
+  --workspace-id $DWAO_WORKSPACE_ID
+```
+
+- [ ] **Step 3: Run analyze-hybrid against the Session-8 labeled dataset**
+
+```bash
+docker compose exec -T api python scripts/calibrate_matching.py analyze-hybrid \
+  --workspace-id $DWAO_WORKSPACE_ID \
+  --labels eval/calibration/dogfood-martech-labeled.md \
+  --lambdas 0.0,0.1,0.2,0.3,0.5,0.7,1.0
+```
+
+Record the output in `eval/calibration/phase-2-6-findings-dwao.md`.
+
+- [ ] **Step 4: Repeat for CleverTap**
+
+Extract CleverTap's ICP from `https://clevertap.com`. Re-label the same 30 posts under the CleverTap lens (~15 min). Run analyze-hybrid against the relabeled set. Record findings.
+
+- [ ] **Step 5: Pick a winning λ**
+
+Pick the λ that satisfies DoD on BOTH workspaces, maximizing P@5 subject to Recall ≥ 0.5 and zero top-5 competitors. Document in `eval/calibration/phase-2-6-lambda-decision.md`.
+
+- [ ] **Step 6: If DoD passes — flip the flag**
+
+```sql
+-- Inside psql:
+UPDATE workspaces SET use_hybrid_scoring = TRUE WHERE id = '<DWAO_WORKSPACE_ID>';
+```
+
+Optionally add a `hybrid_lambda REAL DEFAULT 0.3` column (migration 011) if the winning λ differs from 0.3; otherwise the hardcoded default covers it.
+
+- [ ] **Step 7: Monitor for 2 weeks**
+
+Watch the `/dashboard` output. Compare against the session-8 calibration baseline. If top-5 posts still contain competitor leakage, revert the flag and revisit.
+
+- [ ] **Step 8: If stable — retire legacy `compute_combined_score`**
+
+After 2 weeks stable, open a branch `chore/retire-combined-score`:
+- Remove `compute_combined_score` from `scorer.py`
+- Remove the `else` branch in `pipeline.py` — hybrid becomes the only path
+- Require all new workspaces to have ICP/seller_mirror extracted before first pipeline run
+- Default `workspaces.use_hybrid_scoring` to `TRUE` via migration 011
+
+- [ ] **Step 9: If DoD fails — diagnose per design §5 step 8**
+
+Likely fixes (in order of design preference):
+1. **Encoder asymmetry** — upgrade embedding to `text-embedding-3-large` (Plan B per design §3.4). New migration to widen embedding columns from 1536 to 3072 dimensions; re-embed everything.
+2. **Weak ICP extraction** — tighten the prompt in `extract_icp_and_seller_mirror.py`, bump PROMPT_VERSION. Re-run Dwao extract → backfill → analyze-hybrid.
+3. **λ sweep finds no usable value** — indicates seller-mirror isn't discriminating. Try a fresh prompt (different framing) or switch to an asymmetric retrieval model (BGE / E5) as a Phase 2.7 slice.
+
+Open a GitHub issue for whichever fix is indicated; do not ship hybrid behind the flag until DoD passes.
+
+---
+
+## After every task: update session log + TODO.md
+
+Each merged task gets a terse entry appended to TODO.md's Session log (newest first, 3-5 bullets). Both TODO.md and TODO.html must be updated together per the memory scar about asymmetric edits.
+
+At session end, rewrite TODO.md's Next Session Action Plan per the CLAUDE.md rule.
+
+---
+
+## Self-review of this plan (done — see below)
+
+**Spec coverage vs. design §8:**
+- §8.1 (migrations + models) → Task 1 ✅
+- §8.2 (prompt module + extended /profile/extract) → Tasks 2 + 4 ✅
+- §8.3 (fit_scorer) → Task 3 ✅
+- §8.4 (backfill script) → Task 6 ✅
+- §8.5 (pipeline branch) → Task 5 ✅
+- §8.6 (wizard updates) → Task 7 ✅
+- §8.7 (calibration run) → Task 8 (tooling) + Task 9 (operational run) ✅
+- §8.8 (flip flag, retire legacy) → Task 9 steps 6-8 ✅
+- §8.9 (if DoD fails) → Task 9 step 9 ✅
+
+**Placeholder scan:** All tasks have executable code. Task 9 steps are operational by design — concrete commands, no "TBD".
+
+**Type consistency check:**
+- `compute_fit_score` signature in Task 3 matches usages in Tasks 5 + 6 + 8 ✅
+- `CapabilityProfileVersion.icp_embedding` defined in Task 1, read in Tasks 4 + 5 + 6 + 8 ✅
+- `workspace.use_hybrid_scoring` column defined in Task 1, read in Task 5 ✅
+- `connection.fit_score` column defined in Task 1, read/written in Tasks 5 + 6 ✅
+
+**Known design ambiguities surfaced:**
+- Fit score flooring at 0 (Task 3 PR body flags for reviewer confirmation)
+- Lambda storage: hardcoded 0.3 in Task 5; migration 011 deferred to post-calibration
+- `/profile/update-icp` endpoint included in Task 7 rather than split out
+
+**Open questions for reviewer:**
+- Should the edge case "hybrid flag True but ICP embeddings missing" hard-fail or fall through to legacy? Task 5 chose fall-through-with-warning.
+- Should `compute_intent_score` use the existing `scorer.py` timing decay helper if one exists, to avoid drift? Task 3 re-implements it inline; consolidation is a cleanup opportunity after hybrid ships.

--- a/frontend/src/pages/SignalConfig.tsx
+++ b/frontend/src/pages/SignalConfig.tsx
@@ -314,7 +314,15 @@ export function SignalConfig() {
           </div>
           {error && <div style={errorStyle}>{error}</div>}
           <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
-            <button style={secondaryBtn} onClick={() => setStep(2)}>
+            <button
+              style={secondaryBtn}
+              onClick={() => {
+                // Reset the dirty flag so a subsequent re-extract starts
+                // clean rather than carrying over edits the user abandoned.
+                setIcpEdited(false);
+                setStep(2);
+              }}
+            >
               Back
             </button>
             <button style={primaryBtn} disabled={loading} onClick={handleIcpNext}>

--- a/frontend/src/pages/SignalConfig.tsx
+++ b/frontend/src/pages/SignalConfig.tsx
@@ -17,7 +17,7 @@ interface SignalSelection {
   edited?: ProposedSignal;
 }
 
-type Step = 1 | 2 | 3 | 4 | 5;
+type Step = 1 | 2 | 3 | 4 | 5 | 6;
 
 const containerStyle: React.CSSProperties = {
   maxWidth: 720,
@@ -81,6 +81,8 @@ export function SignalConfig() {
   const [step, setStep] = useState<Step>(1);
   const [whatYouSell, setWhatYouSell] = useState("");
   const [icp, setIcp] = useState("");
+  const [sellerMirror, setSellerMirror] = useState("");
+  const [icpEdited, setIcpEdited] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [proposalEventId, setProposalEventId] = useState<string | null>(null);
@@ -89,6 +91,26 @@ export function SignalConfig() {
   // The v1 wizard only surfaces the LLM-proposed signals; leaving the setter
   // in place means the later UI can be added without refactoring state.
   const [userAdded] = useState<ProposedSignal[]>([]);
+
+  const handleExtractIcp = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await api.post("/profile/extract", {
+        text: whatYouSell,
+      });
+      setIcp(data.icp || "");
+      setSellerMirror(data.seller_mirror || "");
+      setIcpEdited(false);
+      setStep(3);
+    } catch (e) {
+      const detail =
+        (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setError(detail || "Failed to extract ICP. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handlePropose = async () => {
     setLoading(true);
@@ -105,7 +127,7 @@ export function SignalConfig() {
           status: "accepted" as const,
         })),
       );
-      setStep(4);
+      setStep(5);
     } catch (e) {
       const detail =
         (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
@@ -113,6 +135,27 @@ export function SignalConfig() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleIcpNext = async () => {
+    if (icpEdited) {
+      setLoading(true);
+      setError(null);
+      try {
+        await api.post("/profile/update-icp", {
+          icp,
+          seller_mirror: sellerMirror,
+        });
+      } catch (e) {
+        const detail =
+          (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+        setError(detail || "Failed to save ICP edits. Try again.");
+        setLoading(false);
+        return;
+      }
+      setLoading(false);
+    }
+    setStep(4);
   };
 
   const updateStatus = (idx: number, status: SignalStatus) => {
@@ -182,7 +225,7 @@ export function SignalConfig() {
 
   return (
     <div style={containerStyle}>
-      <div style={stepCounterStyle}>Step {step} of 5</div>
+      <div style={stepCounterStyle}>Step {step} of 6</div>
 
       {step === 1 && (
         <section>
@@ -220,18 +263,68 @@ export function SignalConfig() {
             value={icp}
             onChange={(e) => setIcp(e.target.value)}
           />
+          {error && <div style={errorStyle}>{error}</div>}
           <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
             <button style={secondaryBtn} onClick={() => setStep(1)}>
               Back
             </button>
-            <button style={primaryBtn} onClick={() => setStep(3)}>
-              Next
+            <button style={primaryBtn} disabled={loading} onClick={handleExtractIcp}>
+              {loading ? "Analyzing..." : "Next"}
             </button>
           </div>
         </section>
       )}
 
       {step === 3 && (
+        <section>
+          <h1 style={h1Style}>Review who we think your buyers are</h1>
+          <p style={helpStyle}>
+            Before we generate signals, confirm the buyer persona and seller persona we'll
+            be comparing connections against. Edit anything that looks off.
+          </p>
+          <div style={{ marginTop: 16 }}>
+            <div style={{ fontWeight: 500, marginBottom: 4 }}>Your ideal buyer (ICP)</div>
+            <textarea
+              style={textareaStyle}
+              rows={6}
+              value={icp}
+              onChange={(e) => {
+                setIcp(e.target.value);
+                setIcpEdited(true);
+              }}
+            />
+          </div>
+          <div style={{ marginTop: 16 }}>
+            <div style={{ fontWeight: 500, marginBottom: 4 }}>
+              Seller-mirror (subtracted during scoring)
+            </div>
+            <div style={{ fontSize: 12, color: "#888", marginBottom: 4 }}>
+              What OTHER sellers of your capability look like on LinkedIn. We subtract this
+              signal so competing vendors don't rank as buyers.
+            </div>
+            <textarea
+              style={textareaStyle}
+              rows={6}
+              value={sellerMirror}
+              onChange={(e) => {
+                setSellerMirror(e.target.value);
+                setIcpEdited(true);
+              }}
+            />
+          </div>
+          {error && <div style={errorStyle}>{error}</div>}
+          <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
+            <button style={secondaryBtn} onClick={() => setStep(2)}>
+              Back
+            </button>
+            <button style={primaryBtn} disabled={loading} onClick={handleIcpNext}>
+              {loading ? "Saving..." : "Looks right — generate signals"}
+            </button>
+          </div>
+        </section>
+      )}
+
+      {step === 4 && (
         <section>
           <h1 style={h1Style}>Generating signals...</h1>
           <p style={helpStyle}>This takes a few seconds.</p>
@@ -263,7 +356,7 @@ export function SignalConfig() {
         </section>
       )}
 
-      {step === 4 && (
+      {step === 5 && (
         <section>
           <h1 style={h1Style}>Review your signals</h1>
           <p style={helpStyle}>
@@ -309,17 +402,17 @@ export function SignalConfig() {
             </div>
           ))}
           <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
-            <button style={secondaryBtn} onClick={() => setStep(3)}>
+            <button style={secondaryBtn} onClick={() => setStep(4)}>
               Back
             </button>
-            <button style={primaryBtn} onClick={() => setStep(5)}>
+            <button style={primaryBtn} onClick={() => setStep(6)}>
               Next
             </button>
           </div>
         </section>
       )}
 
-      {step === 5 && (
+      {step === 6 && (
         <section>
           <h1 style={h1Style}>Ready to save?</h1>
           <p style={helpStyle}>
@@ -328,7 +421,7 @@ export function SignalConfig() {
           </p>
           {error && <div style={errorStyle}>{error}</div>}
           <div style={{ marginTop: 16, display: "flex", gap: 8 }}>
-            <button style={secondaryBtn} onClick={() => setStep(4)}>
+            <button style={secondaryBtn} onClick={() => setStep(5)}>
               Back
             </button>
             <button style={primaryBtn} disabled={loading} onClick={handleConfirm}>

--- a/frontend/src/pages/SignalConfig.tsx
+++ b/frontend/src/pages/SignalConfig.tsx
@@ -82,7 +82,8 @@ export function SignalConfig() {
   const [whatYouSell, setWhatYouSell] = useState("");
   const [icp, setIcp] = useState("");
   const [sellerMirror, setSellerMirror] = useState("");
-  const [icpEdited, setIcpEdited] = useState(false);
+  const [icpDirty, setIcpDirty] = useState(false);
+  const [sellerMirrorDirty, setSellerMirrorDirty] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [proposalEventId, setProposalEventId] = useState<string | null>(null);
@@ -101,7 +102,8 @@ export function SignalConfig() {
       });
       setIcp(data.icp || "");
       setSellerMirror(data.seller_mirror || "");
-      setIcpEdited(false);
+      setIcpDirty(false);
+      setSellerMirrorDirty(false);
       setStep(3);
     } catch (e) {
       const detail =
@@ -138,14 +140,14 @@ export function SignalConfig() {
   };
 
   const handleIcpNext = async () => {
-    if (icpEdited) {
+    if (icpDirty || sellerMirrorDirty) {
       setLoading(true);
       setError(null);
+      const body: { icp?: string; seller_mirror?: string } = {};
+      if (icpDirty) body.icp = icp;
+      if (sellerMirrorDirty) body.seller_mirror = sellerMirror;
       try {
-        await api.post("/profile/update-icp", {
-          icp,
-          seller_mirror: sellerMirror,
-        });
+        await api.post("/profile/update-icp", body);
       } catch (e) {
         const detail =
           (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
@@ -290,7 +292,7 @@ export function SignalConfig() {
               value={icp}
               onChange={(e) => {
                 setIcp(e.target.value);
-                setIcpEdited(true);
+                setIcpDirty(true);
               }}
             />
           </div>
@@ -308,7 +310,7 @@ export function SignalConfig() {
               value={sellerMirror}
               onChange={(e) => {
                 setSellerMirror(e.target.value);
-                setIcpEdited(true);
+                setSellerMirrorDirty(true);
               }}
             />
           </div>
@@ -317,9 +319,10 @@ export function SignalConfig() {
             <button
               style={secondaryBtn}
               onClick={() => {
-                // Reset the dirty flag so a subsequent re-extract starts
+                // Reset both dirty flags so a subsequent re-extract starts
                 // clean rather than carrying over edits the user abandoned.
-                setIcpEdited(false);
+                setIcpDirty(false);
+                setSellerMirrorDirty(false);
                 setStep(2);
               }}
             >


### PR DESCRIPTION
## Summary

Implements Phase 2.6 of Sonar — replaces single-axis post-similarity matching with a two-axis hybrid: `final_score = fit_score × intent_score`. Fit is computed per connection from LLM-extracted ICP + seller-mirror embeddings; intent is relevance + timing. Ships behind the per-workspace `use_hybrid_scoring` feature flag so existing workspaces stay on the legacy scorer until explicitly flipped.

Design: `docs/phase-2-6/design.md`. Implementation plan: `docs/phase-2-6/implementation.md`.

## Tasks shipped (8 of 9)

Each task has a feature commit and, where the quality reviewer found issues, a follow-up fix commit. All 16 commits below, two-stage reviewed (spec compliance + code quality).

| Task | Commits | Files |
|---|---|---|
| 1. Migrations 008/009/010 + ORM | `6be8e9d` + `0043687` | 3 migrations, `connection.py`, `workspace.py`, round-trip test, `sync_engine` fixture |
| 2. ICP + seller_mirror prompt | `b33a2ed` + `2aa0814` + `90e15e7` | `app/prompts/extract_icp_and_seller_mirror.py` + tests |
| 3. `fit_scorer` service | `d07d4d0` + `91dd3e4` | Pure-function module, 18 unit tests |
| 4. Extend `/profile/extract` | `c64940d` + `448af92` | Persists ICP + seller_mirror + embeddings in one round-trip |
| 5. Pipeline branch on flag | `c25a6f7` | Hybrid scoring path in `_run_pipeline` with fallback |
| 6. `backfill_fit_scores.py` | `1f60822` + `6dfd28a` | One-shot script with batch commits + cost logging |
| 7. Wizard ICP review step + `/profile/update-icp` | `53b8b83` + `b81ae74` | Step inserted between step 2 and signal generation |
| 8. `analyze-hybrid` subcommand | `db6fbc4` | λ sweep with P@5 / Recall@5 / competitor leakage gate |

Plus the plan itself: `19f5283`.

**Tests:** 178/178 passing.

## Task 9 — Operational (NOT in this PR)

Task 9 is the actual calibration run + flag flip + legacy retirement. It cannot be run by CI — it requires:
- Real Dwao and CleverTap workspace IDs
- Live OpenAI API key
- Human judgment on whether DoD passes (P@5 ≥ 0.6, Recall@5 ≥ 0.5, zero top-5 competitors on BOTH workspaces)

The runbook is in the implementation plan, `## Task 9: Operational`.

## Blockers to fix BEFORE flipping the flag

Surfaced during Task 5 quality review. Must be addressed or the first hybrid-scored alert will render broken:

1. **Delivery formatters render `relationship_score=0.0` as "Relationship: 0%"** in Slack / Telegram / email. The hybrid path sets `relationship_score=0.0` because the axis moves to the dashboard degree filter, but the formatters don't know that. Fix: migration to make `alert.relationship_score` nullable + update `delivery/slack.py:35`, `delivery/telegram.py:32`, `delivery/email.py:33` to omit the field when `None`. Or render "N/A (hybrid scoring)".

## Deferred follow-ups (nice-to-haves, file as issues)

- **PROMPT_VERSION logging** — every LLM call should log `PROMPT_VERSION` per CLAUDE.md "LLM and agent discipline." Systemic gap; existing `extract_capability_profile` has the same issue.
- **Per-field dirty tracking in wizard** — currently any edit to ICP or seller_mirror re-embeds both. Worth splitting into separate flags.
- **Race condition in hybrid pipeline fit_score cache** — two concurrent posts from the same connection both compute fit_score. Idempotent result but wastes one embedding call. Low priority until traffic scales.
- **Lambda storage** — currently hardcoded at `0.3` in pipeline. Task 9 calibration picks a λ; if non-default, add `workspaces.hybrid_lambda REAL` in migration 011.
- **Connection fit_score refresh on ICP change** — manual: operator runs `scripts/backfill_fit_scores.py --recompute-all` after `/profile/update-icp`. No automatic invalidation.

## Test plan

- [x] 178 backend tests green
- [x] Frontend `npm run build` clean (93 modules, no errors)
- [ ] **Manual browser walkthrough** of the 6-step wizard (Task 7's Step 6): `docker compose up -d frontend && open http://localhost:5173/signals/setup`. Walk all 6 steps, verify the new step 3 ICP review appears, textareas edit, `/profile/update-icp` fires on edit, signals generate in step 4, save in step 6. Take a screenshot for the merge record.
- [ ] Run Task 9 calibration (Dwao + CleverTap) against the session-8 labeled dataset before flipping `use_hybrid_scoring=True` for any real workspace.
- [ ] Fix the relationship_score=0.0 delivery rendering bug before flipping the flag.

## Review discipline notes

Each task went through `superpowers:subagent-driven-development`: fresh implementer subagent per task, followed by spec-compliance review then code-quality review. Quality reviews caught 1 blocking (Task 1 SQL injection via f-string in a test), 3 important (Task 3 flakiness, Task 4 test-fake brittleness, Task 7 critical-adjacent two-phase write + whitespace-only + back-nav), and multiple nice-to-haves that were fixed in-line or deferred with rationale in commit messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ICP and seller‑mirror extraction (with persistent embeddings), editable review step in the Signals setup wizard, POST /profile/update-icp, and a backfill tool to populate connection fit scores.
  * Optional per‑workspace hybrid Fit×Intent scoring with fit/intent/hybrid computations and calibration tooling (λ sweep).

* **Behavior Changes**
  * Alerts and delivery messages now omit the Relationship score when absent; hybrid scoring can change ranking, priorities, and alert storage.

* **Documentation**
  * Added hybrid scoring implementation plan and runbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->